### PR TITLE
upgrade go version to 1.24.1

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -17,9 +17,9 @@ jobs:
           go-version-file: 'go.mod'
           cache: false # see https://github.com/golangci/golangci-lint-action/issues/807
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.5.0
+        uses: golangci/golangci-lint-action@v6.5.2
         with:
-          version: v1.56.1
+          version: v1.64.6
   unit-tests:
     env:
       COVERAGE: coverage.out

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,10 +6,6 @@ linters-settings:
     min-occurrences: 2
   gocyclo:
     min-complexity: 15
-  govet:
-    check-shadowing: true
-  maligned:
-    suggest-new: true
   misspell:
     locale: US
     ignore-words:
@@ -23,12 +19,15 @@ linters-settings:
       - name: blank-imports
       - name: context-as-argument
       - name: context-keys-type
+      - name: defer
       - name: dot-imports
       - name: error-return
       - name: error-strings
       - name: error-naming
+      - name: early-return
       - name: errorf
       - name: exported
+      - name: import-shadowing
       - name: indent-error-flow
       - name: if-return
       - name: increment-decrement
@@ -52,15 +51,14 @@ linters-settings:
       - name: constant-logical-expr
       - name: confusing-naming
       - name: unnecessary-stmt
-      - name: imports-blacklist
+      - name: use-any
+      - name: imports-blocklist
         arguments:
           - "github.com/pkg/errors"
   gci:
     sections:
       - standard
       - default
-    section-separators:
-      - newLine
 linters:
   disable-all: true
   enable:
@@ -68,7 +66,7 @@ linters:
     - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]
     - errorlint # Errorlint is a linter that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
     - exhaustive # check exhaustiveness of enum switch statements [fast: false, auto-fix: false]
-    - exportloopref # checks for pointers to enclosing loop variables [fast: false, auto-fix: false]
+    - copyloopvar # copyloopvar is a linter detects places where loop variables are copied. Replaces exportloopref since Go1.22
     - gci # Gci controls golang package import order and makes it always deterministic. [fast: true, auto-fix: false]
     - gochecknoinits # Checks that no init functions are present in Go code [fast: true, auto-fix: false]
     - goconst # Finds repeated strings that could be replaced by a constant [fast: true, auto-fix: false]
@@ -77,7 +75,7 @@ linters:
     - godot # Check if comments end in a period [fast: true, auto-fix: true]
     - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true, auto-fix: true]
     - goimports # In addition to fixing imports, goimports also formats your code in the same style as gofmt. [fast: true, auto-fix: true]
-    - gomnd # An analyzer to detect magic numbers. [fast: true, auto-fix: false]
+    - mnd # An analyzer to detect magic numbers. [fast: true, auto-fix: false]
     - goprintffuncname # Checks that printf-like functions are named with `f` at the end [fast: true, auto-fix: false]
     - gosec # (gas) Inspects source code for security problems [fast: false, auto-fix: false]
     - gosimple # (megacheck) Linter for Go source code that specializes in simplifying code [fast: false, auto-fix: false]
@@ -94,7 +92,7 @@ linters:
     - rowserrcheck # checks whether Err of rows is checked successfully [fast: false, auto-fix: false]
     - staticcheck # (megacheck) It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint. [fast: false, auto-fix: false]
     - stylecheck # Stylecheck is a replacement for golint [fast: false, auto-fix: false]
-    - tenv # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17 [fast: false, auto-fix: false]
+    - usetesting # Reports uses of functions with replacement inside the testing package. [auto-fix]
     - testifylint # Checks usage of github.com/stretchr/testify. [fast: false, auto-fix: false]
     - thelper # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers [fast: false, auto-fix: false]
     - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code [fast: false, auto-fix: false]
@@ -174,8 +172,6 @@ run:
     - e2e
     - unit
     - integration
-  skip-dirs:
-    - internal/mocks
   modules-download-mode: readonly
 
 issues:
@@ -186,9 +182,4 @@ issues:
         - gocyclo
     - path: internal/test/fixture # Don't check for magic numbers on fixtures.
       linters:
-        - gomnd
-    - path: internal/kubernetes/*
-      linters:
-        - nolintlint
-        - gci
-        - gocyclo
+        - mnd

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/mongodb-cli/mongocli/v2
 
-go 1.23.6
+go 1.24.1
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/mongodb-cli/mongocli/v2
 
-go 1.22.5
+go 1.23.6
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/internal/cli/auth/login_test.go
+++ b/internal/cli/auth/login_test.go
@@ -129,11 +129,11 @@ Successfully logged in as test@10gen.com.
 
 type confirmMock struct{}
 
-func (confirmMock) Prompt(_ *survey.PromptConfig) (interface{}, error) {
+func (confirmMock) Prompt(_ *survey.PromptConfig) (any, error) {
 	return true, nil
 }
 
-func (confirmMock) Cleanup(_ *survey.PromptConfig, _ interface{}) error {
+func (confirmMock) Cleanup(_ *survey.PromptConfig, _ any) error {
 	return nil
 }
 

--- a/internal/cli/auth/login_test.go
+++ b/internal/cli/auth/login_test.go
@@ -18,7 +18,6 @@ package auth
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -76,7 +75,7 @@ func Test_loginOpts_Run(t *testing.T) {
 		ExpiresIn:       300,
 		Interval:        10,
 	}
-	ctx := context.TODO()
+	ctx := t.Context()
 	mockFlow.
 		EXPECT().
 		RequestCode(ctx).

--- a/internal/cli/auth/logout_test.go
+++ b/internal/cli/auth/logout_test.go
@@ -18,7 +18,6 @@ package auth
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -53,7 +52,7 @@ func Test_logoutOpts_Run(t *testing.T) {
 			Confirm: true,
 		},
 	}
-	ctx := context.TODO()
+	ctx := t.Context()
 	mockFlow.
 		EXPECT().
 		RevokeToken(ctx, gomock.Any(), gomock.Any()).
@@ -83,7 +82,7 @@ func Test_logoutOpts_Run_Keep(t *testing.T) {
 		},
 		keepConfig: true,
 	}
-	ctx := context.TODO()
+	ctx := t.Context()
 	mockFlow.
 		EXPECT().
 		RevokeToken(ctx, gomock.Any(), gomock.Any()).

--- a/internal/cli/config/set.go
+++ b/internal/cli/config/set.go
@@ -43,7 +43,7 @@ func (opts *SetOpts) Run() error {
 			return err
 		}
 	}
-	var value interface{}
+	var value any
 	value = opts.val
 	if search.StringInSlice(config.BooleanProperties(), opts.prop) {
 		value = config.IsTrue(opts.val)

--- a/internal/cli/delete_opts.go
+++ b/internal/cli/delete_opts.go
@@ -46,7 +46,7 @@ func NewDeleteOpts(successMsg, failMsg string) *DeleteOpts {
 
 // Delete deletes a resource not associated to a project, it expects a callback
 // that should perform the deletion from the store.
-func (opts *DeleteOpts) Delete(d interface{}, a ...string) error {
+func (opts *DeleteOpts) Delete(d any, a ...string) error {
 	if !opts.Confirm {
 		fmt.Println(opts.FailMessage())
 		return nil

--- a/internal/cli/iam/projects/list.go
+++ b/internal/cli/iam/projects/list.go
@@ -48,7 +48,7 @@ func (opts *ListOpts) initStore(ctx context.Context) func() error {
 }
 
 func (opts *ListOpts) Run() error {
-	var r interface{}
+	var r any
 	var err error
 	listOptions := opts.NewListOptions()
 	if opts.ConfigOrgID() != "" && config.Service() == config.OpsManagerService {

--- a/internal/cli/iam/teams/describe.go
+++ b/internal/cli/iam/teams/describe.go
@@ -49,7 +49,7 @@ func (opts *DescribeOpts) initStore(ctx context.Context) func() error {
 }
 
 func (opts *DescribeOpts) Run() error {
-	var r interface{}
+	var r any
 	var err error
 
 	if opts.name != "" {

--- a/internal/cli/iam/users/describe.go
+++ b/internal/cli/iam/users/describe.go
@@ -48,7 +48,7 @@ func (opts *DescribeOpts) initStore(ctx context.Context) func() error {
 }
 
 func (opts *DescribeOpts) Run() error {
-	var r interface{}
+	var r any
 	var err error
 
 	if opts.username != "" {

--- a/internal/cli/opsmanager/clusters/describe.go
+++ b/internal/cli/opsmanager/clusters/describe.go
@@ -66,7 +66,7 @@ func (opts *DescribeOpts) validateArg() error {
 	return nil
 }
 
-func (opts *DescribeOpts) cluster() (interface{}, error) {
+func (opts *DescribeOpts) cluster() (any, error) {
 	if opts.ConfigOutput() == "" {
 		return opts.store.OpsManagerCluster(opts.ConfigProjectID(), opts.name)
 	}

--- a/internal/cli/opsmanager/clusters/list.go
+++ b/internal/cli/opsmanager/clusters/list.go
@@ -55,7 +55,7 @@ func (opts *ListOpts) Run() error {
 	return opts.Print(r)
 }
 
-func (opts *ListOpts) clusters() (interface{}, error) {
+func (opts *ListOpts) clusters() (any, error) {
 	if opts.IsPlainOutput() {
 		return opts.store.ProjectClusters(opts.ConfigProjectID(), nil)
 	}

--- a/internal/cli/output_opts.go
+++ b/internal/cli/output_opts.go
@@ -107,7 +107,7 @@ func (opts *OutputOpts) IsCygwinTerminal() bool {
 }
 
 // Print will evaluate the defined format and try to parse it accordingly outputting to the set writer.
-func (opts *OutputOpts) Print(o interface{}) error {
+func (opts *OutputOpts) Print(o any) error {
 	if opts.ConfigOutput() == jsonFormat {
 		return jsonwriter.Print(opts.ConfigWriter(), o)
 	}

--- a/internal/cli/watch_opts.go
+++ b/internal/cli/watch_opts.go
@@ -38,10 +38,10 @@ const (
 	speed       = 100 * time.Millisecond
 )
 
-type Watcher func() (interface{}, bool, error)
+type Watcher func() (any, bool, error)
 
 // Watch allow to init the OutputOpts in a functional way.
-func (opts *WatchOpts) Watch(f Watcher) (interface{}, error) {
+func (opts *WatchOpts) Watch(f Watcher) (any, error) {
 	if f == nil {
 		return nil, errors.New("no watcher provided")
 	}
@@ -63,7 +63,7 @@ func (opts *WatchOpts) Watch(f Watcher) (interface{}, error) {
 
 var backoffCoefficients = []float32{0.5, 1, 2}
 
-func (opts *WatchOpts) exponentialBackoff(f Watcher) (interface{}, bool, error) {
+func (opts *WatchOpts) exponentialBackoff(f Watcher) (any, bool, error) {
 	if opts.IsRetryableErr == nil {
 		return f()
 	}

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -71,11 +71,11 @@ var (
 )
 
 type Setter interface {
-	Set(string, interface{})
+	Set(string, any)
 }
 
 type GlobalSetter interface {
-	SetGlobal(string, interface{})
+	SetGlobal(string, any)
 }
 
 type Saver interface {
@@ -190,20 +190,20 @@ func (p *Profile) SetName(name string) error {
 	return nil
 }
 
-func Set(name string, value interface{}) { Default().Set(name, value) }
-func (p *Profile) Set(name string, value interface{}) {
+func Set(name string, value any) { Default().Set(name, value) }
+func (p *Profile) Set(name string, value any) {
 	settings := viper.GetStringMap(p.Name())
 	settings[name] = value
 	viper.Set(p.name, settings)
 }
 
-func SetGlobal(name string, value interface{}) { viper.Set(name, value) }
-func (*Profile) SetGlobal(name string, value interface{}) {
+func SetGlobal(name string, value any) { viper.Set(name, value) }
+func (*Profile) SetGlobal(name string, value any) {
 	SetGlobal(name, value)
 }
 
-func Get(name string) interface{} { return Default().Get(name) }
-func (p *Profile) Get(name string) interface{} {
+func Get(name string) any { return Default().Get(name) }
+func (p *Profile) Get(name string) any {
 	if viper.IsSet(name) && viper.Get(name) != "" {
 		return viper.Get(name)
 	}

--- a/internal/convert/automation_config_test.go
+++ b/internal/convert/automation_config_test.go
@@ -71,7 +71,7 @@ func TestFromAutomationConfig(t *testing.T) {
 								Mode:                       "Mode",
 								PEMKeyFile:                 "PEMKeyFile",
 							},
-							Security: &map[string]interface{}{
+							Security: &map[string]any{
 								"test": "test",
 							},
 						},
@@ -129,7 +129,7 @@ func TestFromAutomationConfig(t *testing.T) {
 								Mode:                       "Mode",
 								PEMKeyFile:                 "PEMKeyFile",
 							},
-							Security: &map[string]interface{}{
+							Security: &map[string]any{
 								"test": "test",
 							},
 						},
@@ -228,7 +228,7 @@ func TestFromAutomationConfig(t *testing.T) {
 		t.Parallel()
 		config := fixture.MultiMongosAutomationConfig()
 
-		engineConfig := make(map[string]interface{})
+		engineConfig := make(map[string]any)
 		engineConfig["cacheSizeGB"] = 0.5
 		expected := []*ClusterConfig{
 			{

--- a/internal/convert/cluster_config.go
+++ b/internal/convert/cluster_config.go
@@ -136,10 +136,10 @@ func newShardingConfig(c *ClusterConfig) *opsmngr.ShardingConfig {
 		ConfigServerReplica: c.Config.Name,
 		Tags:                c.Tags,
 		Draining:            make([]string, 0),
-		Collections:         make([]*map[string]interface{}, 0),
+		Collections:         make([]*map[string]any, 0),
 	}
 	if rs.Tags == nil {
-		rs.Tags = make([]*map[string]interface{}, 0)
+		rs.Tags = make([]*map[string]any, 0)
 	}
 
 	return rs

--- a/internal/convert/cluster_config_test.go
+++ b/internal/convert/cluster_config_test.go
@@ -184,7 +184,7 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 								Destination: file,
 								Path:        "/data/db/audit.log",
 							},
-							Security: &map[string]interface{}{
+							Security: &map[string]any{
 								"test": "test",
 							},
 						},
@@ -304,10 +304,10 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 							Port:     27017,
 							Priority: pointer.Get[float64](1),
 							Votes:    pointer.Get[float64](1),
-							Security: &map[string]interface{}{
+							Security: &map[string]any{
 								"test": "test",
 							},
-							SetParameter: &map[string]interface{}{
+							SetParameter: &map[string]any{
 								"test": "test",
 							},
 						},
@@ -363,10 +363,10 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 								Destination: file,
 								Path:        "/data/db/mongodb.log",
 							},
-							Security: &map[string]interface{}{
+							Security: &map[string]any{
 								"test": "test",
 							},
-							SetParameter: &map[string]interface{}{
+							SetParameter: &map[string]any{
 								"test": "test",
 							},
 						},
@@ -468,7 +468,7 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 								Destination: file,
 								Path:        "/data/db/audit.log",
 							},
-							Security: &map[string]interface{}{
+							Security: &map[string]any{
 								"test": "test",
 							},
 						},
@@ -598,7 +598,7 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 								Destination: file,
 								Path:        "/data/db/audit.log",
 							},
-							Security: &map[string]interface{}{
+							Security: &map[string]any{
 								"test": "test",
 							},
 						},
@@ -837,9 +837,9 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 					{
 						ConfigServerReplica: "configRS",
 						Name:                "test_config",
-						Collections:         make([]*map[string]interface{}, 0),
+						Collections:         make([]*map[string]any, 0),
 						Draining:            make([]string, 0),
-						Tags:                make([]*map[string]interface{}, 0),
+						Tags:                make([]*map[string]any, 0),
 						Shards: []*opsmngr.Shard{
 							{
 								ID:   "myShard_0",
@@ -1074,9 +1074,9 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 					{
 						ConfigServerReplica: "configRS",
 						Name:                "test_config",
-						Collections:         make([]*map[string]interface{}, 0),
+						Collections:         make([]*map[string]any, 0),
 						Draining:            make([]string, 0),
-						Tags:                make([]*map[string]interface{}, 0),
+						Tags:                make([]*map[string]any, 0),
 						Shards: []*opsmngr.Shard{
 							// Old
 							{

--- a/internal/convert/process_config.go
+++ b/internal/convert/process_config.go
@@ -29,53 +29,53 @@ const (
 
 // ProcessConfig that belongs to a cluster.
 type ProcessConfig struct {
-	ArbiterOnly                      *bool                   `yaml:"arbiterOnly,omitempty" json:"arbiterOnly,omitempty"`
-	AuditLogPath                     string                  `yaml:"auditLogPath,omitempty" json:"auditLogPath,omitempty"`
-	AuditLogDestination              string                  `yaml:"auditLogDestination,omitempty" json:"auditLogDestination,omitempty"`
-	AuditLogFormat                   string                  `yaml:"auditLogFormat,omitempty" json:"auditLogFormat,omitempty"`
-	AuditLogFilter                   string                  `yaml:"auditLogFilter,omitempty" json:"auditLogFilter,omitempty"`
-	BackupRestoreCheckpointTimestamp interface{}             `yaml:"backupRestoreCheckpointTimestamp,omitempty" json:"backupRestoreCheckpointTimestamp,omitempty"`
-	BuildIndexes                     *bool                   `yaml:"buildIndexes,omitempty" json:"buildIndexes,omitempty"`
-	DBPath                           string                  `yaml:"dbPath,omitempty" json:"dbPath,omitempty"`
-	BindIP                           *string                 `yaml:"bindIp,omitempty" json:"bindIp,omitempty"`
-	BindIPAll                        *bool                   `yaml:"bindIpAll,omitempty" json:"bindIpAll,omitempty"`
-	DefaultRWConcern                 *DefaultRWConcern       `yaml:"defaultRWConcern,omitempty" json:"defaultRWConcern,omitempty"` //nolint:tagliatelle // correct from API
-	DirectoryPerDB                   *bool                   `yaml:"directoryPerDB,omitempty" json:"directoryPerDB,omitempty"`
-	Disabled                         bool                    `yaml:"disabled" json:"disabled"`
-	Engine                           string                  `yaml:"engine,omitempty" json:"engine,omitempty"`
-	EnableMajorityReadConcern        *bool                   `yaml:"enableMajorityReadConcern,omitempty" json:"enableMajorityReadConcern,omitempty"`
-	FeatureCompatibilityVersion      string                  `yaml:"featureCompatibilityVersion,omitempty" json:"featureCompatibilityVersion,omitempty"`
-	Hidden                           *bool                   `yaml:"hidden,omitempty" json:"hidden,omitempty"`
-	Hostname                         string                  `yaml:"hostname" json:"hostname"`
-	InMemory                         *map[string]interface{} `yaml:"inMemory,omitempty" json:"inMemory,omitempty"`
-	IndexBuildRetry                  *bool                   `yaml:"indexBuildRetry,omitempty" json:"indexBuildRetry,omitempty"`
-	IPV6                             *bool                   `yaml:"ipv6,omitempty" json:"ipv6,omitempty"`
-	Journal                          *map[string]interface{} `yaml:"journal,omitempty" json:"journal,omitempty"`
-	LogAppend                        bool                    `yaml:"logAppend,omitempty" json:"logAppend,omitempty"`
-	LogDestination                   string                  `yaml:"logDestination,omitempty" json:"logDestination,omitempty"`
-	LogPath                          string                  `yaml:"logPath" json:"logPath"`
-	LogRotate                        string                  `yaml:"logRotate,omitempty" json:"logRotate,omitempty"`
-	LogVerbosity                     int                     `yaml:"logVerbosity,omitempty" json:"logVerbosity,omitempty"`
-	LogQuiet                         bool                    `yaml:"logQuiet,omitempty" json:"logQuiet,omitempty"`
-	SyslogFacility                   string                  `yaml:"syslogFacility,omitempty" json:"syslogFacility,omitempty"`
-	LogTimeStampFormat               string                  `yaml:"logTimeStampFormat,omitempty" json:"logTimeStampFormat,omitempty"`
-	Name                             string                  `yaml:"name,omitempty" json:"name,omitempty"`
-	OperationProfiling               *map[string]interface{} `yaml:"operationProfiling,omitempty" json:"operationProfiling,omitempty"`
-	OplogMinRetentionHours           *float64                `yaml:"oplogMinRetentionHours,omitempty" json:"oplogMinRetentionHours,omitempty"`
-	OplogSizeMB                      *int                    `yaml:"oplogSizeMB,omitempty" json:"oplogSizeMB,omitempty"`
-	Port                             int                     `yaml:"port" json:"port"`
-	Priority                         *float64                `yaml:"priority,omitempty" json:"priority,omitempty"`
-	ProcessType                      string                  `yaml:"processType" json:"processType"`
-	SmallFiles                       *bool                   `yaml:"smallFiles,omitempty" json:"smallFiles,omitempty"`
-	SecondaryDelaySecs               *float64                `yaml:"secondaryDelaySecs,omitempty" json:"secondaryDelaySecs,omitempty"`
-	SlaveDelay                       *float64                `yaml:"slaveDelay,omitempty" json:"slaveDelay,omitempty"`
-	SyncPeriodSecs                   *float64                `yaml:"syncPeriodSecs,omitempty" json:"syncPeriodSecs,omitempty"`
-	Votes                            *float64                `yaml:"votes,omitempty" json:"votes,omitempty"`
-	Security                         *map[string]interface{} `yaml:"security,omitempty" json:"security,omitempty"`
-	SetParameter                     *map[string]interface{} `yaml:"setParameter,omitempty" json:"setParameter,omitempty"`
-	TLS                              *TLS                    `yaml:"tls,omitempty" json:"tls,omitempty"`
-	Version                          string                  `yaml:"version,omitempty" json:"version,omitempty"`
-	WiredTiger                       *map[string]interface{} `yaml:"wiredTiger,omitempty" json:"wiredTiger,omitempty"`
+	ArbiterOnly                      *bool             `yaml:"arbiterOnly,omitempty" json:"arbiterOnly,omitempty"`
+	AuditLogPath                     string            `yaml:"auditLogPath,omitempty" json:"auditLogPath,omitempty"`
+	AuditLogDestination              string            `yaml:"auditLogDestination,omitempty" json:"auditLogDestination,omitempty"`
+	AuditLogFormat                   string            `yaml:"auditLogFormat,omitempty" json:"auditLogFormat,omitempty"`
+	AuditLogFilter                   string            `yaml:"auditLogFilter,omitempty" json:"auditLogFilter,omitempty"`
+	BackupRestoreCheckpointTimestamp any               `yaml:"backupRestoreCheckpointTimestamp,omitempty" json:"backupRestoreCheckpointTimestamp,omitempty"`
+	BuildIndexes                     *bool             `yaml:"buildIndexes,omitempty" json:"buildIndexes,omitempty"`
+	DBPath                           string            `yaml:"dbPath,omitempty" json:"dbPath,omitempty"`
+	BindIP                           *string           `yaml:"bindIp,omitempty" json:"bindIp,omitempty"`
+	BindIPAll                        *bool             `yaml:"bindIpAll,omitempty" json:"bindIpAll,omitempty"`
+	DefaultRWConcern                 *DefaultRWConcern `yaml:"defaultRWConcern,omitempty" json:"defaultRWConcern,omitempty"` //nolint:tagliatelle // correct from API
+	DirectoryPerDB                   *bool             `yaml:"directoryPerDB,omitempty" json:"directoryPerDB,omitempty"`
+	Disabled                         bool              `yaml:"disabled" json:"disabled"`
+	Engine                           string            `yaml:"engine,omitempty" json:"engine,omitempty"`
+	EnableMajorityReadConcern        *bool             `yaml:"enableMajorityReadConcern,omitempty" json:"enableMajorityReadConcern,omitempty"`
+	FeatureCompatibilityVersion      string            `yaml:"featureCompatibilityVersion,omitempty" json:"featureCompatibilityVersion,omitempty"`
+	Hidden                           *bool             `yaml:"hidden,omitempty" json:"hidden,omitempty"`
+	Hostname                         string            `yaml:"hostname" json:"hostname"`
+	InMemory                         *map[string]any   `yaml:"inMemory,omitempty" json:"inMemory,omitempty"`
+	IndexBuildRetry                  *bool             `yaml:"indexBuildRetry,omitempty" json:"indexBuildRetry,omitempty"`
+	IPV6                             *bool             `yaml:"ipv6,omitempty" json:"ipv6,omitempty"`
+	Journal                          *map[string]any   `yaml:"journal,omitempty" json:"journal,omitempty"`
+	LogAppend                        bool              `yaml:"logAppend,omitempty" json:"logAppend,omitempty"`
+	LogDestination                   string            `yaml:"logDestination,omitempty" json:"logDestination,omitempty"`
+	LogPath                          string            `yaml:"logPath" json:"logPath"`
+	LogRotate                        string            `yaml:"logRotate,omitempty" json:"logRotate,omitempty"`
+	LogVerbosity                     int               `yaml:"logVerbosity,omitempty" json:"logVerbosity,omitempty"`
+	LogQuiet                         bool              `yaml:"logQuiet,omitempty" json:"logQuiet,omitempty"`
+	SyslogFacility                   string            `yaml:"syslogFacility,omitempty" json:"syslogFacility,omitempty"`
+	LogTimeStampFormat               string            `yaml:"logTimeStampFormat,omitempty" json:"logTimeStampFormat,omitempty"`
+	Name                             string            `yaml:"name,omitempty" json:"name,omitempty"`
+	OperationProfiling               *map[string]any   `yaml:"operationProfiling,omitempty" json:"operationProfiling,omitempty"`
+	OplogMinRetentionHours           *float64          `yaml:"oplogMinRetentionHours,omitempty" json:"oplogMinRetentionHours,omitempty"`
+	OplogSizeMB                      *int              `yaml:"oplogSizeMB,omitempty" json:"oplogSizeMB,omitempty"`
+	Port                             int               `yaml:"port" json:"port"`
+	Priority                         *float64          `yaml:"priority,omitempty" json:"priority,omitempty"`
+	ProcessType                      string            `yaml:"processType" json:"processType"`
+	SmallFiles                       *bool             `yaml:"smallFiles,omitempty" json:"smallFiles,omitempty"`
+	SecondaryDelaySecs               *float64          `yaml:"secondaryDelaySecs,omitempty" json:"secondaryDelaySecs,omitempty"`
+	SlaveDelay                       *float64          `yaml:"slaveDelay,omitempty" json:"slaveDelay,omitempty"`
+	SyncPeriodSecs                   *float64          `yaml:"syncPeriodSecs,omitempty" json:"syncPeriodSecs,omitempty"`
+	Votes                            *float64          `yaml:"votes,omitempty" json:"votes,omitempty"`
+	Security                         *map[string]any   `yaml:"security,omitempty" json:"security,omitempty"`
+	SetParameter                     *map[string]any   `yaml:"setParameter,omitempty" json:"setParameter,omitempty"`
+	TLS                              *TLS              `yaml:"tls,omitempty" json:"tls,omitempty"`
+	Version                          string            `yaml:"version,omitempty" json:"version,omitempty"`
+	WiredTiger                       *map[string]any   `yaml:"wiredTiger,omitempty" json:"wiredTiger,omitempty"`
 }
 
 // TLS defines TLS parameters for Net.
@@ -99,9 +99,9 @@ type DefaultReadConcern struct {
 }
 
 type DefaultWriteConcern struct {
-	W        interface{} `yaml:"w,omitempty" json:"w,omitempty"` // W can be string or number
-	J        *bool       `yaml:"j,omitempty" json:"j,omitempty"`
-	Wtimeout int         `yaml:"wtimeout" json:"wtimeout"`
+	W        any   `yaml:"w,omitempty" json:"w,omitempty"` // W can be string or number
+	J        *bool `yaml:"j,omitempty" json:"j,omitempty"`
+	Wtimeout int   `yaml:"wtimeout" json:"wtimeout"`
 }
 
 type DefaultRWConcern struct {

--- a/internal/convert/process_config_test.go
+++ b/internal/convert/process_config_test.go
@@ -49,19 +49,19 @@ func Test_newReplicaSetProcessConfig(t *testing.T) {
 			Storage: &opsmngr.Storage{
 				DBPath:         "/data/db",
 				DirectoryPerDB: pointer.Get(true),
-				WiredTiger: &map[string]interface{}{
-					"collectionConfig": map[string]interface{}{},
-					"engineConfig": map[string]interface{}{
+				WiredTiger: &map[string]any{
+					"collectionConfig": map[string]any{},
+					"engineConfig": map[string]any{
 						"cacheSizeGB": 1,
 					},
-					"indexConfig": map[string]interface{}{},
+					"indexConfig": map[string]any{},
 				},
 			},
 			SystemLog: opsmngr.SystemLog{
 				Destination: "file",
 				Path:        "/data/log/mongodb.log",
 			},
-			SetParameter: &map[string]interface{}{
+			SetParameter: &map[string]any{
 				"param": "param",
 			},
 		},
@@ -118,15 +118,15 @@ func Test_newReplicaSetProcessConfig(t *testing.T) {
 			Mode:     "disabled",
 			FIPSMode: &fipsMode,
 		},
-		SetParameter: &map[string]interface{}{
+		SetParameter: &map[string]any{
 			"param": "param",
 		},
-		WiredTiger: &map[string]interface{}{
-			"collectionConfig": map[string]interface{}{},
-			"engineConfig": map[string]interface{}{
+		WiredTiger: &map[string]any{
+			"collectionConfig": map[string]any{},
+			"engineConfig": map[string]any{
 				"cacheSizeGB": 1,
 			},
-			"indexConfig": map[string]interface{}{},
+			"indexConfig": map[string]any{},
 		},
 	}
 	result := newReplicaSetProcessConfig(omm, omp)
@@ -159,14 +159,14 @@ func Test_newConfigRSProcess(t *testing.T) {
 		Disabled:                    false,
 		Hidden:                      pointer.Get(false),
 		TLS:                         &TLS{Mode: "disabled"},
-		WiredTiger: &map[string]interface{}{
-			"collectionConfig": map[string]interface{}{},
-			"engineConfig": map[string]interface{}{
+		WiredTiger: &map[string]any{
+			"collectionConfig": map[string]any{},
+			"engineConfig": map[string]any{
 				"cacheSizeGB": 1,
 			},
-			"indexConfig": map[string]interface{}{},
+			"indexConfig": map[string]any{},
 		},
-		SetParameter: &map[string]interface{}{
+		SetParameter: &map[string]any{
 			"param": "param",
 		},
 	}
@@ -189,12 +189,12 @@ func Test_newConfigRSProcess(t *testing.T) {
 			Storage: &opsmngr.Storage{
 				DBPath:         "/data/db",
 				DirectoryPerDB: pointer.Get(true),
-				WiredTiger: &map[string]interface{}{
-					"collectionConfig": map[string]interface{}{},
-					"engineConfig": map[string]interface{}{
+				WiredTiger: &map[string]any{
+					"collectionConfig": map[string]any{},
+					"engineConfig": map[string]any{
 						"cacheSizeGB": 1,
 					},
-					"indexConfig": map[string]interface{}{},
+					"indexConfig": map[string]any{},
 				},
 			},
 			SystemLog: opsmngr.SystemLog{
@@ -202,7 +202,7 @@ func Test_newConfigRSProcess(t *testing.T) {
 				Path:        "/data/log/mongodb.log",
 			},
 			Sharding: &opsmngr.Sharding{ClusterRole: "configsvr"},
-			SetParameter: &map[string]interface{}{
+			SetParameter: &map[string]any{
 				"param": "param",
 			},
 		},
@@ -244,14 +244,14 @@ func Test_newConfigRSProcess_audit(t *testing.T) {
 		Disabled:                    false,
 		Hidden:                      pointer.Get(false),
 		TLS:                         &TLS{Mode: "disabled"},
-		WiredTiger: &map[string]interface{}{
-			"collectionConfig": map[string]interface{}{},
-			"engineConfig": map[string]interface{}{
+		WiredTiger: &map[string]any{
+			"collectionConfig": map[string]any{},
+			"engineConfig": map[string]any{
 				"cacheSizeGB": 1,
 			},
-			"indexConfig": map[string]interface{}{},
+			"indexConfig": map[string]any{},
 		},
-		SetParameter: &map[string]interface{}{
+		SetParameter: &map[string]any{
 			"param": "param",
 		},
 	}
@@ -271,12 +271,12 @@ func Test_newConfigRSProcess_audit(t *testing.T) {
 			Storage: &opsmngr.Storage{
 				DBPath:         "/data/db",
 				DirectoryPerDB: pointer.Get(true),
-				WiredTiger: &map[string]interface{}{
-					"collectionConfig": map[string]interface{}{},
-					"engineConfig": map[string]interface{}{
+				WiredTiger: &map[string]any{
+					"collectionConfig": map[string]any{},
+					"engineConfig": map[string]any{
 						"cacheSizeGB": 1,
 					},
-					"indexConfig": map[string]interface{}{},
+					"indexConfig": map[string]any{},
 				},
 			},
 			SystemLog: opsmngr.SystemLog{
@@ -284,7 +284,7 @@ func Test_newConfigRSProcess_audit(t *testing.T) {
 				Path:        "/data/log/mongodb.log",
 			},
 			Sharding: &opsmngr.Sharding{ClusterRole: "configsvr"},
-			SetParameter: &map[string]interface{}{
+			SetParameter: &map[string]any{
 				"param": "param",
 			},
 		},
@@ -329,14 +329,14 @@ func Test_newReplicaSetProcess(t *testing.T) {
 		Disabled:                    false,
 		Hidden:                      pointer.Get(false),
 		TLS:                         &TLS{Mode: "disabled"},
-		WiredTiger: &map[string]interface{}{
-			"collectionConfig": map[string]interface{}{},
-			"engineConfig": map[string]interface{}{
+		WiredTiger: &map[string]any{
+			"collectionConfig": map[string]any{},
+			"engineConfig": map[string]any{
 				"cacheSizeGB": 1,
 			},
-			"indexConfig": map[string]interface{}{},
+			"indexConfig": map[string]any{},
 		},
-		SetParameter: &map[string]interface{}{
+		SetParameter: &map[string]any{
 			"enableLocalhostAuthBypass": "false",
 			"auditAuthorizationSuccess": "true",
 		},
@@ -360,19 +360,19 @@ func Test_newReplicaSetProcess(t *testing.T) {
 			Storage: &opsmngr.Storage{
 				DBPath:         "/data/db",
 				DirectoryPerDB: pointer.Get(true),
-				WiredTiger: &map[string]interface{}{
-					"collectionConfig": map[string]interface{}{},
-					"engineConfig": map[string]interface{}{
+				WiredTiger: &map[string]any{
+					"collectionConfig": map[string]any{},
+					"engineConfig": map[string]any{
 						"cacheSizeGB": 1,
 					},
-					"indexConfig": map[string]interface{}{},
+					"indexConfig": map[string]any{},
 				},
 			},
 			SystemLog: opsmngr.SystemLog{
 				Destination: "file",
 				Path:        "/data/log/mongodb.log",
 			},
-			SetParameter: &map[string]interface{}{
+			SetParameter: &map[string]any{
 				"enableLocalhostAuthBypass": "false",
 				"auditAuthorizationSuccess": "true",
 			},
@@ -404,7 +404,7 @@ func Test_newMongosProcessConfig(t *testing.T) {
 				Destination: "file",
 				Path:        "/data/mongos/mongodb.log",
 			},
-			SetParameter: &map[string]interface{}{
+			SetParameter: &map[string]any{
 				"param": "param",
 			},
 			AuditLog: &opsmngr.AuditLog{
@@ -443,7 +443,7 @@ func Test_newMongosProcessConfig(t *testing.T) {
 		ProcessType:                 "mongos",
 		Version:                     "3.6.21-ent",
 		Disabled:                    false,
-		SetParameter: &map[string]interface{}{
+		SetParameter: &map[string]any{
 			"param": "param",
 		},
 	}

--- a/internal/convert/rs_config.go
+++ b/internal/convert/rs_config.go
@@ -24,11 +24,11 @@ import (
 
 // RSConfig shared properties of replica sets, config servers, and sharded clusters.
 type RSConfig struct {
-	Name                        string                    `yaml:"name,omitempty" json:"name,omitempty"`
-	FeatureCompatibilityVersion string                    `yaml:"featureCompatibilityVersion,omitempty" json:"featureCompatibilityVersion,omitempty"`
-	Processes                   []*ProcessConfig          `yaml:"processes,omitempty" json:"processes,omitempty"`
-	Tags                        []*map[string]interface{} `yaml:"tags,omitempty" json:"tags,omitempty"`
-	Version                     string                    `yaml:"version,omitempty" json:"version,omitempty"`
+	Name                        string            `yaml:"name,omitempty" json:"name,omitempty"`
+	FeatureCompatibilityVersion string            `yaml:"featureCompatibilityVersion,omitempty" json:"featureCompatibilityVersion,omitempty"`
+	Processes                   []*ProcessConfig  `yaml:"processes,omitempty" json:"processes,omitempty"`
+	Tags                        []*map[string]any `yaml:"tags,omitempty" json:"tags,omitempty"`
+	Version                     string            `yaml:"version,omitempty" json:"version,omitempty"`
 }
 
 type patcher func(*ProcessConfig, string) *opsmngr.Process

--- a/internal/decryption/log_record.go
+++ b/internal/decryption/log_record.go
@@ -67,7 +67,7 @@ func (logLine *AuditLogLine) decodeLogRecord() (*DecodedLogRecord, error) {
 	}, nil
 }
 
-func processLogRecord(decryptConfig *DecryptSection, logLine *AuditLogLine, lineNb int) (bsonData interface{}, keyInvocationCount uint64, err error) {
+func processLogRecord(decryptConfig *DecryptSection, logLine *AuditLogLine, lineNb int) (bsonData any, keyInvocationCount uint64, err error) {
 	encryptedLogRecord, decodeErr := logLine.decodeLogRecord()
 	if decodeErr != nil {
 		return nil, 0, fmt.Errorf("at line %v: %w: %w", lineNb, ErrLogCorrupted, decodeErr)
@@ -90,7 +90,7 @@ func processLogRecord(decryptConfig *DecryptSection, logLine *AuditLogLine, line
 		return nil, 0, fmt.Errorf("%w at line %v: %w", ErrDecompressionFailure, lineNb, decompressErr)
 	}
 
-	var bsonParsedLogRecord map[string]interface{}
+	var bsonParsedLogRecord map[string]any
 	if bsonErr := bson.Unmarshal(decompressedLogRecord, &bsonParsedLogRecord); bsonErr != nil {
 		return nil, 0, fmt.Errorf("%w at line %v: %w", ErrParse, lineNb, bsonErr)
 	}
@@ -106,6 +106,7 @@ func (logLine *AuditLogLine) logAdditionalAuthData() []byte {
 	const AADByteSize = 8
 
 	additionalAuthData := make([]byte, AADByteSize)
+	//nolint:gosec
 	binary.LittleEndian.PutUint64(additionalAuthData, uint64(logLine.TS.UnixMilli()))
 	return additionalAuthData
 }

--- a/internal/decryption/output.go
+++ b/internal/decryption/output.go
@@ -23,10 +23,10 @@ import (
 )
 
 type AuditLogOutput interface {
-	Warningf(lineNb int, logLine *AuditLogLine, format string, a ...interface{}) error
+	Warningf(lineNb int, logLine *AuditLogLine, format string, a ...any) error
 	Error(lineNb int, logLine *AuditLogLine, err error) error
-	Errorf(lineNb int, logLine *AuditLogLine, format string, a ...interface{}) error
-	LogRecord(lineNb int, logRecord interface{}) error
+	Errorf(lineNb int, logLine *AuditLogLine, format string, a ...any) error
+	LogRecord(lineNb int, logRecord any) error
 }
 
 type auditLogOutputWriter struct {
@@ -71,7 +71,7 @@ func NewAuditLogOutput(out io.Writer) AuditLogOutput {
 	}
 }
 
-func (l *auditLogOutputWriter) writeRecord(value interface{}) error {
+func (l *auditLogOutputWriter) writeRecord(value any) error {
 	jsonVal, err := bson.MarshalExtJSON(value, false, false)
 	if err != nil {
 		return err
@@ -85,7 +85,7 @@ func (l *auditLogOutputWriter) writeRecord(value interface{}) error {
 	return err
 }
 
-func (l *auditLogOutputWriter) Warningf(lineNb int, logLine *AuditLogLine, format string, a ...interface{}) error {
+func (l *auditLogOutputWriter) Warningf(lineNb int, logLine *AuditLogLine, format string, a ...any) error {
 	e := AuditLogError{
 		Level: AuditLogErrorLevelWarning,
 		Line:  lineNb,
@@ -111,10 +111,10 @@ func (l *auditLogOutputWriter) Error(lineNb int, logLine *AuditLogLine, err erro
 	return l.writeRecord(e)
 }
 
-func (l *auditLogOutputWriter) Errorf(lineNb int, logLine *AuditLogLine, format string, a ...interface{}) error {
+func (l *auditLogOutputWriter) Errorf(lineNb int, logLine *AuditLogLine, format string, a ...any) error {
 	return l.Error(lineNb, logLine, fmt.Errorf(format, a...))
 }
 
-func (l *auditLogOutputWriter) LogRecord(_ int, logRecord interface{}) error {
+func (l *auditLogOutputWriter) LogRecord(_ int, logRecord any) error {
 	return l.writeRecord(logRecord)
 }

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -58,7 +58,7 @@ var ErrFileNotFound = errors.New("file not found")
 
 // Load loads a given filename into the out interface.
 // The file should be a valid json or yaml format.
-func Load(fs afero.Fs, filename string, out interface{}) error {
+func Load(fs afero.Fs, filename string, out any) error {
 	if exists, err := afero.Exists(fs, filename); !exists || err != nil {
 		return fmt.Errorf("%w: %s", ErrFileNotFound, filename)
 	}
@@ -89,7 +89,7 @@ func Load(fs afero.Fs, filename string, out interface{}) error {
 
 // Save saves a given data interface into a given file path
 // The file should be a yaml format.
-func Save(fs afero.Fs, filePath string, data interface{}) error {
+func Save(fs afero.Fs, filePath string, data any) error {
 	var content []byte
 
 	if _, err := configType(filePath, []string{yamlName}); err != nil {

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -53,13 +53,13 @@ func TestLoad(t *testing.T) {
 	t.Run("load valid json file", func(t *testing.T) {
 		appFS := afero.NewMemMapFs()
 		_ = afero.WriteFile(appFS, jsonFileName, []byte("{}"), 0600)
-		out := new(map[string]interface{})
+		out := new(map[string]any)
 		require.NoError(t, Load(appFS, jsonFileName, out))
 	})
 	t.Run("load valid yaml file", func(t *testing.T) {
 		appFS := afero.NewMemMapFs()
 		_ = afero.WriteFile(appFS, yamlFileName, []byte(""), 0600)
-		out := new(map[string]interface{})
+		out := new(map[string]any)
 		err := Load(appFS, yamlFileName, out)
 		require.NotErrorIs(t, err, ErrMissingFileType)
 	})

--- a/internal/jsonpathwriter/jsonpathwriter.go
+++ b/internal/jsonpathwriter/jsonpathwriter.go
@@ -25,7 +25,7 @@ import (
 
 var ErrEmptyPath = errors.New("empty jsonpath")
 
-func Print(w io.Writer, path string, obj interface{}) error {
+func Print(w io.Writer, path string, obj any) error {
 	if path == "" {
 		return ErrEmptyPath
 	}
@@ -35,7 +35,7 @@ func Print(w io.Writer, path string, obj interface{}) error {
 		return err
 	}
 
-	var val interface{}
+	var val any
 	if e := json.Unmarshal(jsonString, &val); e != nil {
 		return e
 	}

--- a/internal/jsonwriter/jsonwriter.go
+++ b/internal/jsonwriter/jsonwriter.go
@@ -25,7 +25,7 @@ const (
 	indent = "  "
 )
 
-func Print(w io.Writer, obj interface{}) error {
+func Print(w io.Writer, obj any) error {
 	prettyJSON, err := json.MarshalIndent(obj, prefix, indent)
 	if err != nil {
 		return err

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -139,6 +139,7 @@ func TestWithContext(t *testing.T) {
 		t.Fatalf("New() unexpected error: %v", err)
 	}
 
+	//nolint:usetesting
 	if c.ctx != context.Background() {
 		t.Errorf("New() got %v; expected %v", c.ctx, context.Background())
 	}
@@ -146,6 +147,7 @@ func TestWithContext(t *testing.T) {
 	type myCustomType string
 	var k, v myCustomType = "custom key", "custom value"
 
+	//nolint:usetesting
 	ctx := context.WithValue(context.Background(), k, v)
 
 	c, err = New(Service(config.CloudManagerService), WithContext(ctx))

--- a/internal/templatewriter/templatewriter.go
+++ b/internal/templatewriter/templatewriter.go
@@ -32,7 +32,7 @@ var funcMap = template.FuncMap{
 	"valueOrEmptySlice": valueOrEmptySlice,
 }
 
-func valueOrEmptySlice(slice interface{}) (result interface{}) {
+func valueOrEmptySlice(slice any) (result any) {
 	if slice == nil {
 		return result
 	}
@@ -54,7 +54,7 @@ func newTabWriter(output io.Writer) *tabwriter.Writer {
 // if the optional t is given then it's processed as a go-template,
 // this template will be handled with a tabwriter so you can use tabs (\t)
 // and new lines (\n) to space your content evenly.
-func Print(writer io.Writer, t string, v interface{}) error {
+func Print(writer io.Writer, t string, v any) error {
 	tmpl, err := template.New("output").Funcs(funcMap).Parse(t)
 	if err != nil {
 		return err

--- a/internal/templatewriter/templatewriter_test.go
+++ b/internal/templatewriter/templatewriter_test.go
@@ -25,7 +25,7 @@ import (
 type printTest struct {
 	name     string
 	template string
-	data     interface{}
+	data     any
 	expected string
 	wantErr  require.ErrorAssertionFunc
 }

--- a/internal/test/fixture/automation_configs.go
+++ b/internal/test/fixture/automation_configs.go
@@ -221,7 +221,7 @@ func AutomationConfigWithOneReplicaSet(name string, disabled bool) *opsmngr.Auto
 					Storage: &opsmngr.Storage{
 						DBPath: "/data/db/",
 					},
-					Security: &map[string]interface{}{
+					Security: &map[string]any{
 						"test": "test",
 					},
 					SystemLog: opsmngr.SystemLog{
@@ -440,7 +440,7 @@ func EmptyAutomationConfig() *opsmngr.AutomationConfig {
 }
 
 func MultiMongosAutomationConfig() *opsmngr.AutomationConfig {
-	engineConfig := make(map[string]interface{})
+	engineConfig := make(map[string]any)
 	engineConfig["cacheSizeGB"] = 0.5
 
 	return &opsmngr.AutomationConfig{

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -43,7 +43,7 @@ func CmdValidator(t *testing.T, subject *cobra.Command, nSubCommands int, flags 
 }
 
 // VerifyOutputTemplate validates that the given template string is valid.
-func VerifyOutputTemplate(t *testing.T, tmpl string, typeValue interface{}) {
+func VerifyOutputTemplate(t *testing.T, tmpl string, typeValue any) {
 	t.Helper()
 	var buf bytes.Buffer
 	require.NoError(t, templatewriter.Print(&buf, tmpl, typeValue))

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -26,7 +26,7 @@ import (
 )
 
 // toString tries to cast an interface to string.
-func toString(val interface{}) (string, error) {
+func toString(val any) (string, error) {
 	var u string
 	var ok bool
 	if u, ok = val.(string); !ok {
@@ -36,7 +36,7 @@ func toString(val interface{}) (string, error) {
 }
 
 // URL validates a value is a valid URL for the cli store.
-func URL(val interface{}) error {
+func URL(val any) error {
 	s, err := toString(val)
 	if err != nil {
 		return err
@@ -53,7 +53,7 @@ func URL(val interface{}) error {
 }
 
 // OptionalURL validates a value is a valid URL for the cli store.
-func OptionalURL(val interface{}) error {
+func OptionalURL(val any) error {
 	if val == nil {
 		return nil
 	}
@@ -69,7 +69,7 @@ func OptionalURL(val interface{}) error {
 }
 
 // OptionalObjectID validates a value is a valid ObjectID.
-func OptionalObjectID(val interface{}) error {
+func OptionalObjectID(val any) error {
 	if val == nil {
 		return nil
 	}

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -25,7 +25,7 @@ import (
 func TestURL(t *testing.T) {
 	tests := []struct {
 		name    string
-		val     interface{}
+		val     any
 		wantErr bool
 	}{
 		{
@@ -59,7 +59,7 @@ func TestURL(t *testing.T) {
 func TestOptionalObjectID(t *testing.T) {
 	tests := []struct {
 		name    string
-		val     interface{}
+		val     any
 		wantErr bool
 	}{
 		{
@@ -272,7 +272,7 @@ func TestOptionalURL(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
-		val     interface{}
+		val     any
 		wantErr bool
 	}{
 		{

--- a/test/e2e/cli.go
+++ b/test/e2e/cli.go
@@ -35,6 +35,6 @@ func Bin() (string, error) {
 	return cliPath, nil
 }
 
-func RandInt(max int64) (*big.Int, error) {
-	return rand.Int(rand.Reader, big.NewInt(max))
+func RandInt(maximum int64) (*big.Int, error) {
+	return rand.Int(rand.Reader, big.NewInt(maximum))
 }

--- a/test/e2e/cloud_manager/helper_test.go
+++ b/test/e2e/cloud_manager/helper_test.go
@@ -130,12 +130,12 @@ func generateRSConfig(filename, hostname, clusterName, version, fcVersion string
 					Port:     27000,
 					Priority: pointer.Get[float64](1),
 					Votes:    pointer.Get[float64](1),
-					WiredTiger: &map[string]interface{}{
-						"collectionConfig": map[string]interface{}{},
-						"engineConfig": map[string]interface{}{
+					WiredTiger: &map[string]any{
+						"collectionConfig": map[string]any{},
+						"engineConfig": map[string]any{
 							"cacheSizeGB": 1,
 						},
-						"indexConfig": map[string]interface{}{},
+						"indexConfig": map[string]any{},
 					},
 				},
 				{
@@ -145,12 +145,12 @@ func generateRSConfig(filename, hostname, clusterName, version, fcVersion string
 					Port:     27001,
 					Priority: pointer.Get[float64](1),
 					Votes:    pointer.Get[float64](1),
-					WiredTiger: &map[string]interface{}{
-						"collectionConfig": map[string]interface{}{},
-						"engineConfig": map[string]interface{}{
+					WiredTiger: &map[string]any{
+						"collectionConfig": map[string]any{},
+						"engineConfig": map[string]any{
 							"cacheSizeGB": 1,
 						},
-						"indexConfig": map[string]interface{}{},
+						"indexConfig": map[string]any{},
 					},
 				},
 				{
@@ -160,12 +160,12 @@ func generateRSConfig(filename, hostname, clusterName, version, fcVersion string
 					Port:     27002,
 					Priority: pointer.Get[float64](1),
 					Votes:    pointer.Get[float64](1),
-					WiredTiger: &map[string]interface{}{
-						"collectionConfig": map[string]interface{}{},
-						"engineConfig": map[string]interface{}{
+					WiredTiger: &map[string]any{
+						"collectionConfig": map[string]any{},
+						"engineConfig": map[string]any{
 							"cacheSizeGB": 1,
 						},
-						"indexConfig": map[string]interface{}{},
+						"indexConfig": map[string]any{},
 					},
 				},
 			},
@@ -236,12 +236,12 @@ func generateShardedConfig(filename, hostname, clusterName, version, fcVersion s
 					Port:     29000,
 					Priority: pointer.Get[float64](1),
 					Votes:    pointer.Get[float64](1),
-					WiredTiger: &map[string]interface{}{
-						"collectionConfig": map[string]interface{}{},
-						"engineConfig": map[string]interface{}{
+					WiredTiger: &map[string]any{
+						"collectionConfig": map[string]any{},
+						"engineConfig": map[string]any{
 							"cacheSizeGB": 1,
 						},
-						"indexConfig": map[string]interface{}{},
+						"indexConfig": map[string]any{},
 					},
 				},
 				{
@@ -251,12 +251,12 @@ func generateShardedConfig(filename, hostname, clusterName, version, fcVersion s
 					Port:     29001,
 					Priority: pointer.Get[float64](1),
 					Votes:    pointer.Get[float64](1),
-					WiredTiger: &map[string]interface{}{
-						"collectionConfig": map[string]interface{}{},
-						"engineConfig": map[string]interface{}{
+					WiredTiger: &map[string]any{
+						"collectionConfig": map[string]any{},
+						"engineConfig": map[string]any{
 							"cacheSizeGB": 1,
 						},
-						"indexConfig": map[string]interface{}{},
+						"indexConfig": map[string]any{},
 					},
 				},
 				{
@@ -266,12 +266,12 @@ func generateShardedConfig(filename, hostname, clusterName, version, fcVersion s
 					Port:     29002,
 					Priority: pointer.Get[float64](1),
 					Votes:    pointer.Get[float64](1),
-					WiredTiger: &map[string]interface{}{
-						"collectionConfig": map[string]interface{}{},
-						"engineConfig": map[string]interface{}{
+					WiredTiger: &map[string]any{
+						"collectionConfig": map[string]any{},
+						"engineConfig": map[string]any{
 							"cacheSizeGB": 1,
 						},
-						"indexConfig": map[string]interface{}{},
+						"indexConfig": map[string]any{},
 					},
 				},
 			},
@@ -294,12 +294,12 @@ func generateShardedConfig(filename, hostname, clusterName, version, fcVersion s
 						Port:     27000,
 						Priority: pointer.Get[float64](1),
 						Votes:    pointer.Get[float64](1),
-						WiredTiger: &map[string]interface{}{
-							"collectionConfig": map[string]interface{}{},
-							"engineConfig": map[string]interface{}{
+						WiredTiger: &map[string]any{
+							"collectionConfig": map[string]any{},
+							"engineConfig": map[string]any{
 								"cacheSizeGB": 0.5,
 							},
-							"indexConfig": map[string]interface{}{},
+							"indexConfig": map[string]any{},
 						},
 					},
 					{
@@ -309,12 +309,12 @@ func generateShardedConfig(filename, hostname, clusterName, version, fcVersion s
 						Port:     27001,
 						Priority: pointer.Get[float64](1),
 						Votes:    pointer.Get[float64](1),
-						WiredTiger: &map[string]interface{}{
-							"collectionConfig": map[string]interface{}{},
-							"engineConfig": map[string]interface{}{
+						WiredTiger: &map[string]any{
+							"collectionConfig": map[string]any{},
+							"engineConfig": map[string]any{
 								"cacheSizeGB": 0.5,
 							},
-							"indexConfig": map[string]interface{}{},
+							"indexConfig": map[string]any{},
 						},
 					},
 					{
@@ -324,12 +324,12 @@ func generateShardedConfig(filename, hostname, clusterName, version, fcVersion s
 						Port:     27002,
 						Priority: pointer.Get[float64](1),
 						Votes:    pointer.Get[float64](1),
-						WiredTiger: &map[string]interface{}{
-							"collectionConfig": map[string]interface{}{},
-							"engineConfig": map[string]interface{}{
+						WiredTiger: &map[string]any{
+							"collectionConfig": map[string]any{},
+							"engineConfig": map[string]any{
 								"cacheSizeGB": 0.5,
 							},
-							"indexConfig": map[string]interface{}{},
+							"indexConfig": map[string]any{},
 						},
 					},
 				},
@@ -344,12 +344,12 @@ func generateShardedConfig(filename, hostname, clusterName, version, fcVersion s
 						Port:     28000,
 						Priority: pointer.Get[float64](1),
 						Votes:    pointer.Get[float64](1),
-						WiredTiger: &map[string]interface{}{
-							"collectionConfig": map[string]interface{}{},
-							"engineConfig": map[string]interface{}{
+						WiredTiger: &map[string]any{
+							"collectionConfig": map[string]any{},
+							"engineConfig": map[string]any{
 								"cacheSizeGB": 0.5,
 							},
-							"indexConfig": map[string]interface{}{},
+							"indexConfig": map[string]any{},
 						},
 					},
 					{
@@ -359,12 +359,12 @@ func generateShardedConfig(filename, hostname, clusterName, version, fcVersion s
 						Port:     28001,
 						Priority: pointer.Get[float64](1),
 						Votes:    pointer.Get[float64](1),
-						WiredTiger: &map[string]interface{}{
-							"collectionConfig": map[string]interface{}{},
-							"engineConfig": map[string]interface{}{
+						WiredTiger: &map[string]any{
+							"collectionConfig": map[string]any{},
+							"engineConfig": map[string]any{
 								"cacheSizeGB": 0.5,
 							},
-							"indexConfig": map[string]interface{}{},
+							"indexConfig": map[string]any{},
 						},
 					},
 					{
@@ -374,12 +374,12 @@ func generateShardedConfig(filename, hostname, clusterName, version, fcVersion s
 						Port:     28002,
 						Priority: pointer.Get[float64](1),
 						Votes:    pointer.Get[float64](1),
-						WiredTiger: &map[string]interface{}{
-							"collectionConfig": map[string]interface{}{},
-							"engineConfig": map[string]interface{}{
+						WiredTiger: &map[string]any{
+							"collectionConfig": map[string]any{},
+							"engineConfig": map[string]any{
 								"cacheSizeGB": 0.5,
 							},
-							"indexConfig": map[string]interface{}{},
+							"indexConfig": map[string]any{},
 						},
 					},
 				},

--- a/test/e2e/cloud_manager/key_providers_test.go
+++ b/test/e2e/cloud_manager/key_providers_test.go
@@ -43,6 +43,7 @@ func TestKeyProviders(t *testing.T) {
 	t.Run("List", func(t *testing.T) {
 		filepath := path.Join(tmp, "input.json")
 
+		//nolint:gosec
 		err := os.WriteFile(filepath, []byte(`{"ts":{"$date":{"$numberLong":"1644232049921"}},"version":"0.0","compressionMode":"zstd","keyStoreIdentifier":{"provider":"local","filename":"localKey"},"encryptedKey":{"$binary":{"base64":"+yjPCaKKE1M8fZmPGzGHkyfHYxaw34okpavsHzpd8iPVx2+JjOhXwXw5E2FdI5Rcb5JgmcPUFRPISh/7Si1R/g==","subType":"0"}},"MAC":"qE9fUsGK0EuRrrCRAQAAAAAAAAAAAAAA","auditRecordType":"header"}
 {"ts":{"$date":{"$numberLong":"1644232049922"}},"log":"1Lu4o8XVMM/Rg7GKAQAAAAEAAAAAAAAA/8tXQ36mEd90OaAOzCOSti7N5a2jr0B9ek48/uvyteG/zUJHyM16Hs3wMEhDqTQGBwGhWSHEqXh0/5Jbz6tXsYHhDTMr1BOsn1zaavZScx/CkO5+Hd8Vx+zeFPREtQTe1y+JngXSIroezeyV0/zF4YC4vpug+OZtrEQLNEgwT2bjaqUyaKDbmzCNetd2Ff/eFfMFzinbzKVgXAC7T4YmDuowqXommEXLIBiYh2u4VagwJKZRw5OGZjnvqwyVpSPgGqLxGKUoFigh3NgC6EuGi17VIs5BLRZOIw7+OfbPgQQiKzjCxCk="}`), os.ModePerm)
 		if err != nil {

--- a/test/e2e/config/config_test.go
+++ b/test/e2e/config/config_test.go
@@ -46,7 +46,7 @@ func TestConfig(t *testing.T) {
 		key := os.Getenv("MCLI_PRIVATE_API_KEY")
 		_ = os.Unsetenv("MCLI_PRIVATE_API_KEY")
 		t.Cleanup(func() {
-			_ = os.Setenv("MCLI_PRIVATE_API_KEY", key)
+			t.Setenv("MCLI_PRIVATE_API_KEY", key)
 		})
 		pty, tty, err := pseudotty.Open()
 		if err != nil {
@@ -145,7 +145,7 @@ func TestConfig(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 		}
-		var config map[string]interface{}
+		var config map[string]any
 		if err := json.Unmarshal(resp, &config); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/test/e2e/decryption/decryption.go
+++ b/test/e2e/decryption/decryption.go
@@ -46,12 +46,12 @@ func DumpToTemp(files embed.FS, srcFile, destFile string) error {
 	return os.WriteFile(destFile, content, fs.ModePerm)
 }
 
-func parseJSON(contents []byte) ([]map[string]interface{}, error) {
-	var res []map[string]interface{}
+func parseJSON(contents []byte) ([]map[string]any, error) {
+	var res []map[string]any
 
 	s := bufio.NewScanner(bytes.NewReader(contents))
 	for s.Scan() {
-		var item map[string]interface{}
+		var item map[string]any
 		err := json.Unmarshal(s.Bytes(), &item)
 		if err != nil {
 			return nil, err

--- a/tools/templates-checker/astparsing/astparsing.go
+++ b/tools/templates-checker/astparsing/astparsing.go
@@ -25,12 +25,7 @@ import (
 )
 
 const (
-	cobraCommandTypeName             = "*github.com/spf13/cobra.Command"
-	testingTypeName                  = "*testing.T"
-	testPrefix                       = "Test"
-	verifyOutputTemplateMod          = "test"
-	verifyOutputTemplateName         = "VerifyOutputTemplate"
-	verifyOutputTemplateNumberOfArgs = 3
+	cobraCommandTypeName = "*github.com/spf13/cobra.Command"
 )
 
 var stringDelimiters = []rune{'`', '\'', '"'}
@@ -48,8 +43,8 @@ type CommandBuilderInfo struct {
 	TemplateValue     string
 }
 
-func LoadCommandBuilderInfos(packages []*packages.Package) []*CommandBuilderInfo {
-	commandBuilderFuncDecls := findCommandBuilderFuncDecl(packages)
+func LoadCommandBuilderInfos(p []*packages.Package) []*CommandBuilderInfo {
+	commandBuilderFuncDecls := findCommandBuilderFuncDecl(p)
 
 	builderFuncs := make([]*CommandBuilderInfo, 0)
 
@@ -68,11 +63,11 @@ func LoadCommandBuilderInfos(packages []*packages.Package) []*CommandBuilderInfo
 }
 
 // Iterate through all to find all command builder functions.
-func findCommandBuilderFuncDecl(packages []*packages.Package) []*CommandBuilderFunc {
+func findCommandBuilderFuncDecl(p []*packages.Package) []*CommandBuilderFunc {
 	builderFuncs := make([]*CommandBuilderFunc, 0)
 
 	// Loop through all declarations in every package, file
-	for _, pkg := range packages {
+	for _, pkg := range p {
 		for _, file := range pkg.Syntax {
 			// Loop through all declarations, this can be variable, function, ... declarations
 			for _, declaration := range file.Decls {

--- a/tools/templates-checker/templateparsing/templateparsing.go
+++ b/tools/templates-checker/templateparsing/templateparsing.go
@@ -159,8 +159,8 @@ func ident(value string, depth int) string {
 	return fmt.Sprintf("%*s%s", depth*spacesPerDepth, "", value)
 }
 
-func ParseTemplate(template string) (*TemplateCallTree, error) {
-	parseTree, err := parse.Parse("templ", template, "{{", "}}", templateFuncs)
+func ParseTemplate(t string) (*TemplateCallTree, error) {
+	parseTree, err := parse.Parse("templ", t, "{{", "}}", templateFuncs)
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +349,7 @@ func pipelineToIdentifiers(pipeline *parse.PipeNode) ([]string, error) {
 	}
 }
 
-func IsNil(i interface{}) bool {
+func IsNil(i any) bool {
 	return i == nil || (reflect.ValueOf(i).Kind() == reflect.Ptr && reflect.ValueOf(i).IsNil())
 }
 


### PR DESCRIPTION
In order to enable dependency upgrades, we need to upgrade go version to the latest, that requires upgarding the linter and resolve any issues resulted in the upgrade.