### PR TITLE
Upgrade linter and action

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -17,9 +17,9 @@ jobs:
           go-version-file: 'go.mod'
           cache: false # see https://github.com/golangci/golangci-lint-action/issues/807
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.5.2
+        uses: golangci/golangci-lint-action@v7.0.0
         with:
-          version: v1.64.6
+          version: v2.0.1
   unit-tests:
     env:
       COVERAGE: coverage.out

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,185 +1,134 @@
-linters-settings:
-  errorlint:
-    comparison: false
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gocyclo:
-    min-complexity: 15
-  misspell:
-    locale: US
-    ignore-words:
-      - cancelled
-  revive:
-    # see https://github.com/mgechev/revive#available-rules for details.
-    ignore-generated-header: true
-    severity: warning
-    max-open-files: 2048
-    rules:
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: defer
-      - name: dot-imports
-      - name: error-return
-      - name: error-strings
-      - name: error-naming
-      - name: early-return
-      - name: errorf
-      - name: exported
-      - name: import-shadowing
-      - name: indent-error-flow
-      - name: if-return
-      - name: increment-decrement
-      - name: var-naming
-      - name: var-declaration
-      - name: package-comments
-      - name: range
-      - name: receiver-naming
-      - name: time-naming
-      - name: unexported-return
-      - name: indent-error-flow
-      - name: errorf
-      - name: empty-block
-      - name: superfluous-else
-      - name: struct-tag
-      - name: unused-parameter
-      - name: unreachable-code
-      - name: redefines-builtin-id
-      - name: early-return
-      - name: unused-receiver
-      - name: constant-logical-expr
-      - name: confusing-naming
-      - name: unnecessary-stmt
-      - name: use-any
-      - name: imports-blocklist
-        arguments:
-          - "github.com/pkg/errors"
-  gci:
-    sections:
-      - standard
-      - default
-linters:
-  disable-all: true
-  enable:
-    - dogsled # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f()) [fast: true, auto-fix: false]
-    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]
-    - errorlint # Errorlint is a linter that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - exhaustive # check exhaustiveness of enum switch statements [fast: false, auto-fix: false]
-    - copyloopvar # copyloopvar is a linter detects places where loop variables are copied. Replaces exportloopref since Go1.22
-    - gci # Gci controls golang package import order and makes it always deterministic. [fast: true, auto-fix: false]
-    - gochecknoinits # Checks that no init functions are present in Go code [fast: true, auto-fix: false]
-    - goconst # Finds repeated strings that could be replaced by a constant [fast: true, auto-fix: false]
-    - gocritic # Provides diagnostics that check for bugs, performance and style issues. [fast: false, auto-fix: false]
-    - gocyclo # Computes and checks the cyclomatic complexity of functions [fast: true, auto-fix: false]
-    - godot # Check if comments end in a period [fast: true, auto-fix: true]
-    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true, auto-fix: true]
-    - goimports # In addition to fixing imports, goimports also formats your code in the same style as gofmt. [fast: true, auto-fix: true]
-    - mnd # An analyzer to detect magic numbers. [fast: true, auto-fix: false]
-    - goprintffuncname # Checks that printf-like functions are named with `f` at the end [fast: true, auto-fix: false]
-    - gosec # (gas) Inspects source code for security problems [fast: false, auto-fix: false]
-    - gosimple # (megacheck) Linter for Go source code that specializes in simplifying code [fast: false, auto-fix: false]
-    - govet # (vet, vetshadow) Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string [fast: false, auto-fix: false]
-    - ineffassign # Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
-    - makezero # Finds slice declarations with non-zero initial length [fast: false, auto-fix: false]
-    - misspell # Finds commonly misspelled English words in comments [fast: true, auto-fix: true]
-    - nakedret # Finds naked returns in functions greater than a specified function length [fast: true, auto-fix: false]
-    - noctx # noctx finds sending http request without context.Context [fast: false, auto-fix: false]
-    - nolintlint # Reports ill-formed or insufficient nolint directives [fast: true, auto-fix: false]
-    - prealloc # Finds slice declarations that could potentially be pre-allocated [fast: true, auto-fix: false]
-    - predeclared # find code that shadows one of Go's predeclared identifiers [fast: true, auto-fix: false]
-    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint. [fast: false, auto-fix: false]
-    - rowserrcheck # checks whether Err of rows is checked successfully [fast: false, auto-fix: false]
-    - staticcheck # (megacheck) It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint. [fast: false, auto-fix: false]
-    - stylecheck # Stylecheck is a replacement for golint [fast: false, auto-fix: false]
-    - usetesting # Reports uses of functions with replacement inside the testing package. [auto-fix]
-    - testifylint # Checks usage of github.com/stretchr/testify. [fast: false, auto-fix: false]
-    - thelper # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers [fast: false, auto-fix: false]
-    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code [fast: false, auto-fix: false]
-    - unconvert # Remove unnecessary type conversions [fast: false, auto-fix: false]
-    - unparam # Reports unused function parameters [fast: false, auto-fix: false]
-    - unused # (megacheck) Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
-    - usestdlibvars # A linter that detect the possibility to use variables/constants from the Go standard library. [fast: true, auto-fix: false]
-    - wastedassign # wastedassign finds wasted assignment statements. [fast: false, auto-fix: false]
-    - whitespace # Tool for detection of leading and trailing whitespace [fast: true, auto-fix: true]
-
-  # don't enable:
-  # - bodyclose # checks whether HTTP response body is closed successfully [fast: false, auto-fix: false]
-  # - depguard # Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
-  # - asasalint # check for pass []any as any in variadic func(...any) [fast: false, auto-fix: false]
-  # - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers [fast: true, auto-fix: false]
-  # - bidichk # Checks for dangerous unicode character sequences [fast: true, auto-fix: false]
-  # - containedctx # containedctx is a linter that detects struct contained context.Context field [fast: true, auto-fix: false]
-  # - contextcheck # check the function whether use a non-inherited context [fast: false, auto-fix: false]
-  # - cyclop # checks function and package cyclomatic complexity [fast: false, auto-fix: false]
-  # - decorder # check declaration order and count of types, constants, variables and functions [fast: true, auto-fix: false]
-  # - deadcode  # [deprecated] Finds unused code [fast: false, auto-fix: false]
-  # - dupl # Tool for code clone detection [fast: true, auto-fix: false]
-  # - durationcheck # check for two durations multiplied together [fast: false, auto-fix: false]
-  # - errchkjson # Checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted. [fast: false, auto-fix: false]
-  # - errname # Checks that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`. [fast: false, auto-fix: false]
-  # - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13. [fast: false, auto-fix: false]
-  # - execinquery # execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds [fast: false, auto-fix: false]
-  # - exhaustivestruct #[deprecated]: Checks if all struct's fields are initialized [fast: false, auto-fix: false]
-  # - exhaustruct # Checks if all structure fields are initialized [fast: false, auto-fix: false]
-  # - forbidigo # Forbids identifiers [fast: true, auto-fix: false]
-  # - forcetypeassert # finds forced type assertions [fast: true, auto-fix: false]
-  # - funlen # Tool for detection of long functions [fast: true, auto-fix: false]
-  # - gochecknoglobals # check that no global variables exist [fast: true, auto-fix: false]
-  # - gocognit # Computes and checks the cognitive complexity of functions [fast: true, auto-fix: false]
-  # - godox # Tool for detection of FIXME, TODO and other comment keywords [fast: true, auto-fix: false]
-  # - goerr113 # Golang linter to check the errors handling expressions [fast: false, auto-fix: false]
-  # - gofumpt # Gofumpt checks whether code was gofumpt-ed. [fast: true, auto-fix: true]
-  # - goheader # Checks is file header matches to pattern [fast: true, auto-fix: false]
-  # - golint #[deprecated]: Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes [fast: false, auto-fix: false]
-  # - gomoddirectives # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod. [fast: true, auto-fix: false]
-  # - gomodguard # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations. [fast: true, auto-fix: false]
-  # - grouper # An analyzer to analyze expression groups. [fast: true, auto-fix: false]
-  # - ifshort # [deprecated] Checks that your code uses short syntax for if-statements whenever possible [fast: true, auto-fix: false]
-  # - importas # Enforces consistent import aliases [fast: false, auto-fix: false]
-  # - interfacebloat # A linter that checks the number of methods inside an interface. [fast: true, auto-fix: false]
-  # - interfacer # [deprecated]: Linter that suggests narrower interface types [fast: false, auto-fix: false]
-  # - ireturn # Accept Interfaces, Return Concrete Types [fast: false, auto-fix: false]
-  # - lll # Reports long lines [fast: true, auto-fix: false]
-  # - logrlint # Check logr arguments. [fast: false, auto-fix: false]
-  # - maintidx # maintidx measures the maintainability index of each function. [fast: true, auto-fix: false]
-  # - maligned #[deprecated]: Tool to detect Go structs that would take less memory if their fields were sorted [fast: false, auto-fix: false]
-  # - nestif # Reports deeply nested if statements [fast: true, auto-fix: false]
-  # - nilerr # Finds the code that returns nil even if it checks that the error is not nil. [fast: false, auto-fix: false]
-  # - nilnil # Checks that there is no simultaneous return of `nil` error and an invalid value. [fast: false, auto-fix: false]
-  # - nlreturn # nlreturn checks for a new line before return and branch statements to increase code clarity [fast: true, auto-fix: false]
-  # - nonamedreturns # Reports all named returns [fast: false, auto-fix: false]
-  # - nosnakecase #[deprecated]: nosnakecase is a linter that detects snake case of variable naming and function name. [fast: true, auto-fix: false]
-  # - nosprintfhostport # Checks for misuse of Sprintf to construct a host with port in a URL. [fast: true, auto-fix: false]
-  # - paralleltest # paralleltest detects missing usage of t.Parallel() method in your Go test [fast: false, auto-fix: false]
-  # - promlinter # Check Prometheus metrics naming via promlint [fast: true, auto-fix: false]
-  # - reassign # Checks that package variables are not reassigned [fast: true, auto-fix: false]
-  # - scopelint #[deprecated]: Scopelint checks for unpinned variables in go programs [fast: true, auto-fix: false]
-  # - sqlclosecheck # Checks that sql.Rows and sql.Stmt are closed. [fast: false, auto-fix: false]
-  # - structcheck # [deprecated] Finds unused struct fields [fast: false, auto-fix: false]
-  # - tagliatelle # Checks the struct tags. [fast: true, auto-fix: false]
-  # - testpackage # linter that makes you use a separate _test package [fast: true, auto-fix: false]
-  # - tparallel # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes [fast: false, auto-fix: false]
-  # - varcheck # [deprecated] Finds unused global variables and constants [fast: false, auto-fix: false]
-  # - varnamelen # checks that the length of a variable's name matches its scope [fast: false, auto-fix: false]
-  # - wrapcheck # Checks that errors returned from external packages are wrapped [fast: false, auto-fix: false]
-  # - wsl # Whitespace Linter - Forces you to use empty lines! [fast: true, auto-fix: false]
-
+version: "2"
 run:
-  tests: true
-  timeout: 10m
   build-tags:
     - e2e
     - unit
     - integration
   modules-download-mode: readonly
-
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    - path: e2e # Don't check for cyclomatic complexity on e2e file.
-      linters:
-        - gocyclo
-    - path: internal/test/fixture # Don't check for magic numbers on fixtures.
-      linters:
-        - mnd
+  tests: true
+linters:
+  default: none
+  enable:
+    - copyloopvar
+    - dogsled
+    - errcheck
+    - errorlint
+    - exhaustive
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - goprintffuncname
+    - gosec
+    - govet
+    - ineffassign
+    - makezero
+    - misspell
+    - mnd
+    - nakedret
+    - noctx
+    - nolintlint
+    - prealloc
+    - predeclared
+    - revive
+    - rowserrcheck
+    - staticcheck
+    - testifylint
+    - thelper
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - usetesting
+    - wastedassign
+    - whitespace
+  settings:
+    errorlint:
+      comparison: false
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocyclo:
+      min-complexity: 15
+    misspell:
+      locale: US
+      ignore-rules:
+        - cancelled
+    revive:
+      max-open-files: 2048
+      severity: warning
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: defer
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: early-return
+        - name: errorf
+        - name: exported
+        - name: import-shadowing
+        - name: indent-error-flow
+        - name: if-return
+        - name: increment-decrement
+        - name: var-naming
+        - name: var-declaration
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+        - name: empty-block
+        - name: superfluous-else
+        - name: struct-tag
+        - name: unused-parameter
+        - name: unreachable-code
+        - name: redefines-builtin-id
+        - name: early-return
+        - name: unused-receiver
+        - name: constant-logical-expr
+        - name: confusing-naming
+        - name: unnecessary-stmt
+        - name: use-any
+        - name: imports-blocklist
+          arguments:
+            - github.com/pkg/errors
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gocyclo
+        path: e2e
+      - linters:
+          - mnd
+        path: internal/test/fixture
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/internal/cli/output_opts.go
+++ b/internal/cli/output_opts.go
@@ -83,7 +83,7 @@ func (opts *OutputOpts) IsJSONPathOutput() bool {
 }
 
 func (opts *OutputOpts) IsPlainOutput() bool {
-	return !(opts.IsJSONOutput() || opts.IsGoTemplate() || opts.IsJSONPathOutput())
+	return !opts.IsJSONOutput() && !opts.IsGoTemplate() && !opts.IsJSONPathOutput()
 }
 
 // ConfigWriter returns the io.Writer.

--- a/tools/templates-checker/astparsing/astparsing.go
+++ b/tools/templates-checker/astparsing/astparsing.go
@@ -369,7 +369,7 @@ func getRelatedTemplateFromCallExpr(pkg *packages.Package, callExpr *ast.CallExp
 
 	// If there's a string literal that's not a template ignore it
 	case *ast.BasicLit:
-		if !(strings.Contains(templateArg.Value, "{{") && strings.Contains(templateArg.Value, "}}")) {
+		if !strings.Contains(templateArg.Value, "{{") || !strings.Contains(templateArg.Value, "}}") {
 			return nil, nil
 		}
 	}


### PR DESCRIPTION
Upgrading linter from 1.64.6 -> 2.0.1 
Upgrading linter action from 6.5.2 -> 7.0.0

the upgrade requires migrating the configuration file using the newly added command
`golangci-lint migrate`