### PR TITLE
CLOUDP-308818: set JIRA ticket reporter to EA team

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -52,6 +52,9 @@
                   ],
                   "assignee": {
                     "name": "'"${JIRA_ASSIGNEE}"'"
+                  },
+                  "reporter": {
+                    "name": "'"${JIRA_ASSIGNEE}"'"
                   }
               }
             }')

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -47,6 +47,9 @@
                   ],
                   "assignee": {
                     "name": "'"${JIRA_ASSIGNEE}"'"
+                  },
+                  "reporter": {
+                    "name": "'"${JIRA_ASSIGNEE}"'"
                   }
               }
             }')


### PR DESCRIPTION
since we are sharing the APIx jira key, the reporter is always set as `apix automation`, we are moving it to `Cloud Ops Manager Escalation`