### PR TITLE
(DOCSP-41804) Document sort order for snapshots list commands

### DIFF
--- a/docs/command/mongocli-cloud-manager-backups-snapshots-list.txt
+++ b/docs/command/mongocli-cloud-manager-backups-snapshots-list.txt
@@ -14,6 +14,8 @@ mongocli cloud-manager backups snapshots list
 
 List snapshots for a project and cluster.
 
+Returns snapshots in order from newest to oldest retained snapshot.
+
 Syntax
 ------
 

--- a/docs/command/mongocli-ops-manager-backups-snapshots-list.txt
+++ b/docs/command/mongocli-ops-manager-backups-snapshots-list.txt
@@ -14,6 +14,8 @@ mongocli ops-manager backups snapshots list
 
 List snapshots for a project and cluster.
 
+Returns snapshots in order from newest to oldest retained snapshot.
+
 Syntax
 ------
 

--- a/internal/cli/opsmanager/backup/snapshots/list.go
+++ b/internal/cli/opsmanager/backup/snapshots/list.go
@@ -63,6 +63,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list <clusterId>",
 		Short:   "List snapshots for a project and cluster.",
+		Long:    "List snapshots for a project and cluster, in order from newest to oldest retained snapshot.",
 		Aliases: []string{"ls"},
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{

--- a/internal/cli/opsmanager/backup/snapshots/list.go
+++ b/internal/cli/opsmanager/backup/snapshots/list.go
@@ -63,7 +63,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list <clusterId>",
 		Short:   "List snapshots for a project and cluster.",
-		Long:    "List snapshots for a project and cluster, in order from newest to oldest retained snapshot.",
+		Long:    "Returns snapshots in order from newest to oldest retained snapshot.",
 		Aliases: []string{"ls"},
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{


### PR DESCRIPTION
## Proposed changes
Based on the feedback item: https://mongodb.ideas.aha.io/ideas/FF-I-1192 it was confirmed that the list of backup snapshots returned by the OpsManager Admin API (and therefore the mongocli) is in time order descending. This should be added to the documentation in the linked docs pages. ( [mongocli ops-manager backups snapshots list](https://www.mongodb.com/docs/mongocli/current/command/mongocli-ops-manager-backups-snapshots-list/)
and [mongocli cloud-manager backups snapshots list](https://www.mongodb.com/docs/mongocli/current/command/mongocli-cloud-manager-backups-snapshots-list/#mongocli-cloud-manager-backups-snapshots-list)) 

_Jira ticket:_ [DOCSP-41804](https://jira.mongodb.org/browse/DOCSP-41804)


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
