### PR TITLE
DEVPROD-17955: remove writes to s3://downloads.mongodb.org

### DIFF
--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -341,26 +341,6 @@ tasks:
       - func: "upload dist"
       - command: s3.put
         params:
-          aws_key: ${download_center_aws_key}
-          aws_secret: ${download_center_aws_secret}
-          local_files_include_filter:
-            - src/github.com/mongodb/mongodb-cli/dist/*.tar.gz
-            - src/github.com/mongodb/mongodb-cli/dist/*.zip
-            - src/github.com/mongodb/mongodb-cli/dist/*.deb
-            - src/github.com/mongodb/mongodb-cli/dist/*.rpm
-            - src/github.com/mongodb/mongodb-cli/dist/*.tgz
-            - src/github.com/mongodb/mongodb-cli/dist/*.json
-            - src/github.com/mongodb/mongodb-cli/dist/*.msi
-            - src/github.com/mongodb/mongodb-cli/dist/*.sig
-          remote_file: mongocli/
-          build_variants:
-            - release_mongocli_github
-          bucket: downloads.mongodb.org
-          permissions: public-read
-          content_type: ${content_type|application/x-gzip}
-          display_name: downloads-center-
-      - command: s3.put
-        params:
           role_arn: "arn:aws:iam::119629040606:role/s3-access.cdn-origin-mongocli"
           local_files_include_filter:
             - src/github.com/mongodb/mongodb-cli/dist/*.tar.gz
@@ -377,7 +357,7 @@ tasks:
           bucket: cdn-origin-mongocli
           permissions: private
           content_type: ${content_type|application/x-gzip}
-          display_name: downloads-center-new-
+          display_name: downloads-center-
       - func: "send slack notification"
   - name: push_mongocli_generate
     patchable: false


### PR DESCRIPTION
This commit removes writes to the downloads.mongodb.org S3 bucket. We have been serving traffic for mongocli from the new cdn-origin-mongocli bucket for a few weeks now without any disruption, so we should be safe to remove writing to the old bucket and complete the migration.