### PR TITLE
CLOUDP-311402: Fix resync confirmation message and add test

### DIFF
--- a/internal/cli/opsmanager/clusters/resync.go
+++ b/internal/cli/opsmanager/clusters/resync.go
@@ -48,6 +48,9 @@ func (opts *resyncOpts) initStore(ctx context.Context) func() error {
 }
 
 func (opts *resyncOpts) Run() error {
+	if !opts.confirm {
+		return nil
+	}
 	current, err := opts.store.GetAutomationConfig(opts.ConfigProjectID())
 	if err != nil {
 		return err

--- a/internal/cli/opsmanager/clusters/resync_test.go
+++ b/internal/cli/opsmanager/clusters/resync_test.go
@@ -55,6 +55,23 @@ func TestResync_Run(t *testing.T) {
 	}
 }
 
+func TestResync_RunWithoutConfirmation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := mocks.NewMockAutomationPatcher(ctrl)
+
+	opts := &resyncOpts{
+		store:       mockStore,
+		confirm:     false,
+		clusterName: "myReplicaSet2",
+	}
+
+	// No store methods should be called when confirm is false
+
+	if err := opts.Run(); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+}
+
 func TestResyncBuilder(t *testing.T) {
 	test.CmdValidator(
 		t,


### PR DESCRIPTION
# Proposed changes
This commit fixes an issue where the resync command would attempt to
modify the automation config even when the user declined the confirmation 
prompt. Added a unit test to verify the early return behaviour when confirmation is false.

_Jira ticket:_ [CLOUDP-311402](https://jira.mongodb.org/browse/CLOUDP-311402)