### PR TITLE
upgrade go version to 1.25.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/mongodb-cli/mongocli/v2
 
-go 1.24.1
+go 1.25.1
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
In order to enable dependency upgrades and related https://github.com/mongodb/mongodb-cli/actions/workflows/code-health.yml, we need to upgrade go version to the latest