### PR TITLE
CLOUDP-383487: Fix cluster update removing replica set properties

### DIFF
--- a/internal/convert/automation_config.go
+++ b/internal/convert/automation_config.go
@@ -43,6 +43,8 @@ func FromAutomationConfig(c *opsmngr.AutomationConfig) []*ClusterConfig {
 	}
 	for _, rs := range c.ReplicaSets {
 		newRS := newReplicaSetCluster(rs.ID, len(rs.Members))
+		newRS.Settings = rs.Settings
+		newRS.WriteConcernMajorityJournalDefault = rs.WriteConcernMajorityJournalDefault
 		for j, m := range rs.Members {
 			for k := len(c.Processes) - 1; k >= 0; k-- {
 				p := c.Processes[k]

--- a/internal/convert/automation_config_test.go
+++ b/internal/convert/automation_config_test.go
@@ -35,13 +35,23 @@ func TestFromAutomationConfig(t *testing.T) {
 			{
 				RSConfig: RSConfig{
 					Name: name,
+					Settings: &map[string]any{
+						"chainingAllowed": true,
+					},
+					WriteConcernMajorityJournalDefault: "true",
 					Processes: []*ProcessConfig{
 						{
-							ArbiterOnly:                 pointer.Get(false),
-							BuildIndexes:                pointer.Get(true),
-							DBPath:                      "/data/db/",
-							Disabled:                    false,
-							Hidden:                      pointer.Get(false),
+							ArbiterOnly:  pointer.Get(false),
+							BuildIndexes: pointer.Get(true),
+							Compression: &map[string]any{
+								"compressors": []any{"snappy"},
+							},
+							DBPath:   "/data/db/",
+							Disabled: false,
+							Hidden:   pointer.Get(false),
+							MemberTags: &map[string]string{
+								"region": "us-east-1",
+							},
 							Hostname:                    "host0",
 							LogPath:                     "/data/db/mongodb.log",
 							LogDestination:              file,
@@ -93,13 +103,23 @@ func TestFromAutomationConfig(t *testing.T) {
 			{
 				RSConfig: RSConfig{
 					Name: name,
+					Settings: &map[string]any{
+						"chainingAllowed": true,
+					},
+					WriteConcernMajorityJournalDefault: "true",
 					Processes: []*ProcessConfig{
 						{
-							ArbiterOnly:                 pointer.Get(false),
-							BuildIndexes:                pointer.Get(true),
-							DBPath:                      "/data/db/",
-							Disabled:                    true,
-							Hidden:                      pointer.Get(false),
+							ArbiterOnly:  pointer.Get(false),
+							BuildIndexes: pointer.Get(true),
+							Compression: &map[string]any{
+								"compressors": []any{"snappy"},
+							},
+							DBPath:   "/data/db/",
+							Disabled: true,
+							Hidden:   pointer.Get(false),
+							MemberTags: &map[string]string{
+								"region": "us-east-1",
+							},
 							Hostname:                    "host0",
 							LogPath:                     "/data/db/mongodb.log",
 							LogDestination:              file,

--- a/internal/convert/cluster_config.go
+++ b/internal/convert/cluster_config.go
@@ -16,6 +16,7 @@ package convert
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 
 	"go.mongodb.org/ops-manager/opsmngr"
@@ -169,28 +170,56 @@ func patchProcesses(out *opsmngr.AutomationConfig, newReplicaSetID string, newPr
 	}
 }
 
-// keepSettings if the process exists keep settings we don't expose via the CLI config file.
+// keepSettings preserves server-side fields that the CLI's describe/update
+// roundtrip would otherwise silently drop. It walks the Process reflectively
+// and, for every nil-able field (pointer, slice, map, interface), copies the
+// old value onto the new process when the new value is nil. It recurses into
+// struct and non-nil pointer-to-struct fields so nested optional blocks
+// (e.g. Args26.NET.Compression, Args26.Storage.WiredTiger) are preserved too.
+//
+// Primitive scalars (string, int, bool, float) are deliberately NOT merged:
+// the zero value is ambiguous with "user cleared this", and the CLI's
+// ProcessConfig already roundtrips the scalar fields we surface, so they
+// cannot be silently lost through this path.
+//
+// Trade-off: a user cannot unset a previously-set nil-able field by omitting
+// it from the YAML — old will always win when new is nil. We accept this
+// because the recurring bug is fields getting wiped, not preserved, and an
+// explicit per-field allow-list has to be extended every time the SDK grows
+// a new optional.
 func keepSettings(oldProcess *opsmngr.Process, newProcesses []*opsmngr.Process, pos int) {
-	if oldProcess.Args26.BasisTech != nil && newProcesses[pos].Args26.BasisTech == nil {
-		newProcesses[pos].Args26.BasisTech = oldProcess.Args26.BasisTech
+	mergeKeepNilable(
+		reflect.ValueOf(newProcesses[pos]).Elem(),
+		reflect.ValueOf(oldProcess).Elem(),
+	)
+}
+
+// mergeKeepNilable copies src -> dst for every nil-able field on dst that is
+// currently nil. dst and src must be the same struct type.
+func mergeKeepNilable(dst, src reflect.Value) {
+	if dst.Kind() != reflect.Struct || src.Kind() != reflect.Struct {
+		return
 	}
-	if oldProcess.Args26.OperationProfiling != nil && newProcesses[pos].Args26.OperationProfiling == nil {
-		newProcesses[pos].Args26.OperationProfiling = oldProcess.Args26.OperationProfiling
-	}
-	if oldProcess.Args26.ProcessManagement != nil && newProcesses[pos].Args26.ProcessManagement == nil {
-		newProcesses[pos].Args26.ProcessManagement = oldProcess.Args26.ProcessManagement
-	}
-	if oldProcess.Args26.SNMP != nil && newProcesses[pos].Args26.SNMP == nil {
-		newProcesses[pos].Args26.SNMP = oldProcess.Args26.SNMP
-	}
-	if oldProcess.Args26.NET.Compression != nil && newProcesses[pos].Args26.NET.Compression == nil {
-		newProcesses[pos].Args26.NET.Compression = oldProcess.Args26.NET.Compression
-	}
-	if oldProcess.Args26.NET.MaxIncomingConnections != nil && newProcesses[pos].Args26.NET.MaxIncomingConnections == nil {
-		newProcesses[pos].Args26.NET.MaxIncomingConnections = oldProcess.Args26.NET.MaxIncomingConnections
-	}
-	if oldProcess.Args26.NET.ServiceExecutor != "" && newProcesses[pos].Args26.NET.ServiceExecutor == "" {
-		newProcesses[pos].Args26.NET.ServiceExecutor = oldProcess.Args26.NET.ServiceExecutor
+	for i := 0; i < dst.NumField(); i++ {
+		df, sf := dst.Field(i), src.Field(i)
+		if !df.CanSet() {
+			continue
+		}
+		switch df.Kind() {
+		case reflect.Ptr:
+			switch {
+			case df.IsNil() && !sf.IsNil():
+				df.Set(sf)
+			case !df.IsNil() && !sf.IsNil() && df.Elem().Kind() == reflect.Struct:
+				mergeKeepNilable(df.Elem(), sf.Elem())
+			}
+		case reflect.Map, reflect.Slice, reflect.Interface:
+			if df.IsNil() && !sf.IsNil() {
+				df.Set(sf)
+			}
+		case reflect.Struct:
+			mergeKeepNilable(df, sf)
+		}
 	}
 }
 

--- a/internal/convert/cluster_config.go
+++ b/internal/convert/cluster_config.go
@@ -205,7 +205,7 @@ func mergeKeepNilable(dst, src reflect.Value) {
 		if !df.CanSet() {
 			continue
 		}
-		switch df.Kind() {
+		switch df.Kind() { //nolint:exhaustive // primitive and non-nil-able kinds are intentionally skipped; zero-value is ambiguous with "user cleared this"
 		case reflect.Ptr:
 			switch {
 			case df.IsNil() && !sf.IsNil():

--- a/internal/convert/cluster_config.go
+++ b/internal/convert/cluster_config.go
@@ -171,17 +171,26 @@ func patchProcesses(out *opsmngr.AutomationConfig, newReplicaSetID string, newPr
 
 // keepSettings if the process exists keep settings we don't expose via the CLI config file.
 func keepSettings(oldProcess *opsmngr.Process, newProcesses []*opsmngr.Process, pos int) {
-	if oldProcess.Args26.BasisTech != nil {
+	if oldProcess.Args26.BasisTech != nil && newProcesses[pos].Args26.BasisTech == nil {
 		newProcesses[pos].Args26.BasisTech = oldProcess.Args26.BasisTech
 	}
-	if oldProcess.Args26.OperationProfiling != nil {
+	if oldProcess.Args26.OperationProfiling != nil && newProcesses[pos].Args26.OperationProfiling == nil {
 		newProcesses[pos].Args26.OperationProfiling = oldProcess.Args26.OperationProfiling
 	}
-	if oldProcess.Args26.ProcessManagement != nil {
+	if oldProcess.Args26.ProcessManagement != nil && newProcesses[pos].Args26.ProcessManagement == nil {
 		newProcesses[pos].Args26.ProcessManagement = oldProcess.Args26.ProcessManagement
 	}
-	if oldProcess.Args26.SNMP != nil {
+	if oldProcess.Args26.SNMP != nil && newProcesses[pos].Args26.SNMP == nil {
 		newProcesses[pos].Args26.SNMP = oldProcess.Args26.SNMP
+	}
+	if oldProcess.Args26.NET.Compression != nil && newProcesses[pos].Args26.NET.Compression == nil {
+		newProcesses[pos].Args26.NET.Compression = oldProcess.Args26.NET.Compression
+	}
+	if oldProcess.Args26.NET.MaxIncomingConnections != nil && newProcesses[pos].Args26.NET.MaxIncomingConnections == nil {
+		newProcesses[pos].Args26.NET.MaxIncomingConnections = oldProcess.Args26.NET.MaxIncomingConnections
+	}
+	if oldProcess.Args26.NET.ServiceExecutor != "" && newProcesses[pos].Args26.NET.ServiceExecutor == "" {
+		newProcesses[pos].Args26.NET.ServiceExecutor = oldProcess.Args26.NET.ServiceExecutor
 	}
 }
 

--- a/internal/convert/cluster_config.go
+++ b/internal/convert/cluster_config.go
@@ -202,25 +202,31 @@ func mergeKeepNilable(dst, src reflect.Value) {
 	}
 	for i := 0; i < dst.NumField(); i++ {
 		df, sf := dst.Field(i), src.Field(i)
-		if !df.CanSet() {
-			continue
-		}
-		switch df.Kind() { //nolint:exhaustive // primitive and non-nil-able kinds are intentionally skipped; zero-value is ambiguous with "user cleared this"
-		case reflect.Ptr:
-			switch {
-			case df.IsNil() && !sf.IsNil():
-				df.Set(sf)
-			case !df.IsNil() && !sf.IsNil() && df.Elem().Kind() == reflect.Struct:
-				mergeKeepNilable(df.Elem(), sf.Elem())
-			}
-		case reflect.Map, reflect.Slice, reflect.Interface:
-			if df.IsNil() && !sf.IsNil() {
-				df.Set(sf)
-			}
-		case reflect.Struct:
-			mergeKeepNilable(df, sf)
+		if df.CanSet() {
+			mergeField(df, sf)
 		}
 	}
+}
+
+// mergeField dispatches a single struct field: copies src -> dst if dst is a
+// nil nil-able, or recurses into struct / non-nil pointer-to-struct fields.
+func mergeField(df, sf reflect.Value) {
+	k := df.Kind()
+	if k == reflect.Struct {
+		mergeKeepNilable(df, sf)
+		return
+	}
+	if k == reflect.Ptr && !df.IsNil() && !sf.IsNil() && df.Elem().Kind() == reflect.Struct {
+		mergeKeepNilable(df.Elem(), sf.Elem())
+		return
+	}
+	if isNilableKind(k) && df.IsNil() && !sf.IsNil() {
+		df.Set(sf)
+	}
+}
+
+func isNilableKind(k reflect.Kind) bool {
+	return k == reflect.Ptr || k == reflect.Map || k == reflect.Slice || k == reflect.Interface
 }
 
 // patchReplicaSet patches the replica set if it exists, else adds it as a new replica set.

--- a/internal/convert/cluster_config_test.go
+++ b/internal/convert/cluster_config_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-test/deep"
 	"github.com/mongodb/mongodb-cli/mongocli/v2/internal/pointer"
 	"github.com/mongodb/mongodb-cli/mongocli/v2/internal/test/fixture"
+	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -154,6 +155,9 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 						Args26: opsmngr.Args26{
 							NET: opsmngr.Net{
 								Port: 27017,
+								Compression: &map[string]any{
+									"compressors": []any{"snappy"},
+								},
 								TLS: &opsmngr.TLS{
 									CAFile:                     "CAFile",
 									CertificateKeyFile:         "CertificateKeyFile",
@@ -261,8 +265,15 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 								Votes:              1,
 								SlaveDelay:         pointer.Get[float64](1),
 								SecondaryDelaySecs: pointer.Get[float64](1),
+								Tags: &map[string]string{
+									"region": "us-east-1",
+								},
 							},
 						},
+						Settings: &map[string]any{
+							"chainingAllowed": true,
+						},
+						WriteConcernMajorityJournalDefault: "true",
 					},
 					// New
 					{
@@ -324,6 +335,9 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 						Args26: opsmngr.Args26{
 							NET: opsmngr.Net{
 								Port: 27017,
+								Compression: &map[string]any{
+									"compressors": []any{"snappy"},
+								},
 							},
 							Replication: &opsmngr.Replication{
 								ReplSetName: "replica_set_1",
@@ -441,6 +455,9 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 						Args26: opsmngr.Args26{
 							NET: opsmngr.Net{
 								Port: 27017,
+								Compression: &map[string]any{
+									"compressors": []any{"snappy"},
+								},
 								TLS: &opsmngr.TLS{
 									CAFile:                     "CAFile",
 									CertificateKeyFile:         "CertificateKeyFile",
@@ -571,6 +588,9 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 						Args26: opsmngr.Args26{
 							NET: opsmngr.Net{
 								Port: 27017,
+								Compression: &map[string]any{
+									"compressors": []any{"snappy"},
+								},
 								TLS: &opsmngr.TLS{
 									CAFile:                     "CAFile",
 									CertificateKeyFile:         "CertificateKeyFile",
@@ -1111,4 +1131,38 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_keepSettings_preservesNetFields(t *testing.T) {
+	t.Parallel()
+	compression := &map[string]any{"compressors": []any{"snappy"}}
+	maxConn := pointer.Get(500)
+
+	oldProcess := &opsmngr.Process{
+		Args26: opsmngr.Args26{
+			NET: opsmngr.Net{
+				Port:                   27017,
+				Compression:            compression,
+				MaxIncomingConnections: maxConn,
+				ServiceExecutor:        "adaptive",
+			},
+		},
+	}
+
+	// New process has no Net fields set (simulates hand-written config)
+	newProcesses := []*opsmngr.Process{
+		{
+			Args26: opsmngr.Args26{
+				NET: opsmngr.Net{
+					Port: 27017,
+				},
+			},
+		},
+	}
+
+	keepSettings(oldProcess, newProcesses, 0)
+
+	assert.Equal(t, compression, newProcesses[0].Args26.NET.Compression)
+	assert.Equal(t, maxConn, newProcesses[0].Args26.NET.MaxIncomingConnections)
+	assert.Equal(t, "adaptive", newProcesses[0].Args26.NET.ServiceExecutor)
 }

--- a/internal/convert/cluster_config_test.go
+++ b/internal/convert/cluster_config_test.go
@@ -330,13 +330,28 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 					DeploymentAuthMechanisms: []string{},
 				},
 				Processes: []*opsmngr.Process{
-					// Old
+					// Old — keepSettings preserves server-side TLS/Security/AuditLog
+					// that the hand-written YAML did not re-specify.
 					{
 						Args26: opsmngr.Args26{
 							NET: opsmngr.Net{
 								Port: 27017,
 								Compression: &map[string]any{
 									"compressors": []any{"snappy"},
+								},
+								TLS: &opsmngr.TLS{
+									CAFile:                     "CAFile",
+									CertificateKeyFile:         "CertificateKeyFile",
+									CertificateKeyFilePassword: "CertificateKeyFilePassword",
+									CertificateSelector:        "CertificateSelector",
+									ClusterCertificateSelector: "ClusterCertificateSelector",
+									ClusterFile:                "ClusterFile",
+									ClusterPassword:            "ClusterPassword",
+									CRLFile:                    "CRLFile",
+									DisabledProtocols:          "DisabledProtocols",
+									FIPSMode:                   &fipsMode,
+									Mode:                       "Mode",
+									PEMKeyFile:                 "PEMKeyFile",
 								},
 							},
 							Replication: &opsmngr.Replication{
@@ -348,6 +363,13 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 							SystemLog: opsmngr.SystemLog{
 								Destination: file,
 								Path:        "/data/db/mongodb.log",
+							},
+							AuditLog: &opsmngr.AuditLog{
+								Destination: file,
+								Path:        "/data/db/audit.log",
+							},
+							Security: &map[string]any{
+								"test": "test",
 							},
 						},
 						LogRotate: &opsmngr.LogRotate{
@@ -1144,7 +1166,6 @@ func Test_keepSettings_preservesNetFields(t *testing.T) {
 				Port:                   27017,
 				Compression:            compression,
 				MaxIncomingConnections: maxConn,
-				ServiceExecutor:        "adaptive",
 			},
 		},
 	}
@@ -1164,5 +1185,83 @@ func Test_keepSettings_preservesNetFields(t *testing.T) {
 
 	assert.Equal(t, compression, newProcesses[0].Args26.NET.Compression)
 	assert.Equal(t, maxConn, newProcesses[0].Args26.NET.MaxIncomingConnections)
-	assert.Equal(t, "adaptive", newProcesses[0].Args26.NET.ServiceExecutor)
+}
+
+// Test_keepSettings_genericDeepMerge exercises the reflection-based merge
+// across several levels of the Process struct to prove that any nil-able
+// field not covered by an explicit per-field check is still preserved.
+func Test_keepSettings_genericDeepMerge(t *testing.T) {
+	t.Parallel()
+
+	basisTech := &map[string]any{"rootDir": "/opt/basistech"}
+	snmp := &map[string]any{"agentAddress": "0.0.0.0"}
+	processMgmt := &map[string]any{"timeZoneInfo": "/usr/share/zoneinfo"}
+	opProf := &map[string]any{"mode": "slowOp"}
+	wiredTiger := &map[string]any{"engineConfig": map[string]any{"cacheSizeGB": 4}}
+	inMemory := &map[string]any{"engineConfig": map[string]any{"inMemorySizeGB": 2}}
+	logLevel := pointer.Get(2)
+
+	oldProcess := &opsmngr.Process{
+		LogLevel: logLevel,
+		Args26: opsmngr.Args26{
+			BasisTech:          basisTech,
+			SNMP:               snmp,
+			ProcessManagement:  processMgmt,
+			OperationProfiling: opProf,
+			Storage: &opsmngr.Storage{
+				WiredTiger: wiredTiger,
+				InMemory:   inMemory,
+			},
+			NET: opsmngr.Net{
+				Port: 27017,
+			},
+		},
+	}
+
+	// New process omits everything except what PatchAutomationConfig would
+	// set from the CLI YAML.
+	newProcesses := []*opsmngr.Process{
+		{
+			Args26: opsmngr.Args26{
+				NET: opsmngr.Net{Port: 27017},
+			},
+		},
+	}
+
+	keepSettings(oldProcess, newProcesses, 0)
+
+	assert.Equal(t, logLevel, newProcesses[0].LogLevel, "Process-level nil-able should be preserved")
+	assert.Equal(t, basisTech, newProcesses[0].Args26.BasisTech)
+	assert.Equal(t, snmp, newProcesses[0].Args26.SNMP)
+	assert.Equal(t, processMgmt, newProcesses[0].Args26.ProcessManagement)
+	assert.Equal(t, opProf, newProcesses[0].Args26.OperationProfiling)
+	assert.NotNil(t, newProcesses[0].Args26.Storage, "Storage pointer should be preserved when new is nil")
+	assert.Equal(t, wiredTiger, newProcesses[0].Args26.Storage.WiredTiger)
+	assert.Equal(t, inMemory, newProcesses[0].Args26.Storage.InMemory)
+}
+
+// Test_keepSettings_doesNotOverrideUserValues ensures the merge never
+// overwrites a non-nil field on the new process with the old value.
+func Test_keepSettings_doesNotOverrideUserValues(t *testing.T) {
+	t.Parallel()
+
+	oldCompression := &map[string]any{"compressors": []any{"snappy"}}
+	newCompression := &map[string]any{"compressors": []any{"zstd"}}
+
+	oldProcess := &opsmngr.Process{
+		Args26: opsmngr.Args26{
+			NET: opsmngr.Net{Compression: oldCompression},
+		},
+	}
+	newProcesses := []*opsmngr.Process{
+		{
+			Args26: opsmngr.Args26{
+				NET: opsmngr.Net{Compression: newCompression},
+			},
+		},
+	}
+
+	keepSettings(oldProcess, newProcesses, 0)
+
+	assert.Equal(t, newCompression, newProcesses[0].Args26.NET.Compression)
 }

--- a/internal/convert/process_config.go
+++ b/internal/convert/process_config.go
@@ -30,7 +30,6 @@ const (
 // ProcessConfig that belongs to a cluster.
 type ProcessConfig struct {
 	ArbiterOnly                      *bool              `yaml:"arbiterOnly,omitempty" json:"arbiterOnly,omitempty"`
-	CPUAffinity                      []int              `yaml:"cpuAffinity,omitempty" json:"cpuAffinity,omitempty"`
 	AuditLogPath                     string             `yaml:"auditLogPath,omitempty" json:"auditLogPath,omitempty"`
 	AuditLogDestination              string             `yaml:"auditLogDestination,omitempty" json:"auditLogDestination,omitempty"`
 	AuditLogFormat                   string             `yaml:"auditLogFormat,omitempty" json:"auditLogFormat,omitempty"`
@@ -41,8 +40,7 @@ type ProcessConfig struct {
 	BindIP                           *string            `yaml:"bindIp,omitempty" json:"bindIp,omitempty"`
 	BindIPAll                        *bool              `yaml:"bindIpAll,omitempty" json:"bindIpAll,omitempty"`
 	Compression                      *map[string]any    `yaml:"compression,omitempty" json:"compression,omitempty"`
-	MaxIncomingConnections           *int               `yaml:"maxIncomingConnections,omitempty" json:"maxIncomingConnections,omitempty"`
-	ServiceExecutor                  string             `yaml:"serviceExecutor,omitempty" json:"serviceExecutor,omitempty"`
+	CPUAffinity                      []int              `yaml:"cpuAffinity,omitempty" json:"cpuAffinity,omitempty"`
 	DefaultRWConcern                 *DefaultRWConcern  `yaml:"defaultRWConcern,omitempty" json:"defaultRWConcern,omitempty"` //nolint:tagliatelle // correct from API
 	DirectoryPerDB                   *bool              `yaml:"directoryPerDB,omitempty" json:"directoryPerDB,omitempty"`
 	Disabled                         bool               `yaml:"disabled" json:"disabled"`
@@ -51,7 +49,6 @@ type ProcessConfig struct {
 	FeatureCompatibilityVersion      string             `yaml:"featureCompatibilityVersion,omitempty" json:"featureCompatibilityVersion,omitempty"`
 	Hidden                           *bool              `yaml:"hidden,omitempty" json:"hidden,omitempty"`
 	Horizons                         *map[string]string `yaml:"horizons,omitempty" json:"horizons,omitempty"`
-	MemberTags                       *map[string]string `yaml:"memberTags,omitempty" json:"memberTags,omitempty"`
 	Hostname                         string             `yaml:"hostname" json:"hostname"`
 	InMemory                         *map[string]any    `yaml:"inMemory,omitempty" json:"inMemory,omitempty"`
 	IndexBuildRetry                  *bool              `yaml:"indexBuildRetry,omitempty" json:"indexBuildRetry,omitempty"`
@@ -65,6 +62,8 @@ type ProcessConfig struct {
 	LogQuiet                         bool               `yaml:"logQuiet,omitempty" json:"logQuiet,omitempty"`
 	SyslogFacility                   string             `yaml:"syslogFacility,omitempty" json:"syslogFacility,omitempty"`
 	LogTimeStampFormat               string             `yaml:"logTimeStampFormat,omitempty" json:"logTimeStampFormat,omitempty"`
+	MaxIncomingConnections           *int               `yaml:"maxIncomingConnections,omitempty" json:"maxIncomingConnections,omitempty"`
+	MemberTags                       *map[string]string `yaml:"memberTags,omitempty" json:"memberTags,omitempty"`
 	Name                             string             `yaml:"name,omitempty" json:"name,omitempty"`
 	OperationProfiling               *map[string]any    `yaml:"operationProfiling,omitempty" json:"operationProfiling,omitempty"`
 	OplogMinRetentionHours           *float64           `yaml:"oplogMinRetentionHours,omitempty" json:"oplogMinRetentionHours,omitempty"`
@@ -78,6 +77,7 @@ type ProcessConfig struct {
 	SyncPeriodSecs                   *float64           `yaml:"syncPeriodSecs,omitempty" json:"syncPeriodSecs,omitempty"`
 	Votes                            *float64           `yaml:"votes,omitempty" json:"votes,omitempty"`
 	Security                         *map[string]any    `yaml:"security,omitempty" json:"security,omitempty"`
+	ServiceExecutor                  string             `yaml:"serviceExecutor,omitempty" json:"serviceExecutor,omitempty"`
 	SetParameter                     *map[string]any    `yaml:"setParameter,omitempty" json:"setParameter,omitempty"`
 	TLS                              *TLS               `yaml:"tls,omitempty" json:"tls,omitempty"`
 	Version                          string             `yaml:"version,omitempty" json:"version,omitempty"`

--- a/internal/convert/process_config.go
+++ b/internal/convert/process_config.go
@@ -29,58 +29,59 @@ const (
 
 // ProcessConfig that belongs to a cluster.
 type ProcessConfig struct {
-	ArbiterOnly                      *bool             `yaml:"arbiterOnly,omitempty" json:"arbiterOnly,omitempty"`
-	AuditLogPath                     string            `yaml:"auditLogPath,omitempty" json:"auditLogPath,omitempty"`
-	AuditLogDestination              string            `yaml:"auditLogDestination,omitempty" json:"auditLogDestination,omitempty"`
-	AuditLogFormat                   string            `yaml:"auditLogFormat,omitempty" json:"auditLogFormat,omitempty"`
-	AuditLogFilter                   string            `yaml:"auditLogFilter,omitempty" json:"auditLogFilter,omitempty"`
-	BackupRestoreCheckpointTimestamp any               `yaml:"backupRestoreCheckpointTimestamp,omitempty" json:"backupRestoreCheckpointTimestamp,omitempty"`
-	BuildIndexes                     *bool             `yaml:"buildIndexes,omitempty" json:"buildIndexes,omitempty"`
-	DBPath                           string            `yaml:"dbPath,omitempty" json:"dbPath,omitempty"`
-	BindIP                           *string           `yaml:"bindIp,omitempty" json:"bindIp,omitempty"`
-	BindIPAll                        *bool             `yaml:"bindIpAll,omitempty" json:"bindIpAll,omitempty"`
-	Compression                      *map[string]any   `yaml:"compression,omitempty" json:"compression,omitempty"`
-	MaxIncomingConnections           *int              `yaml:"maxIncomingConnections,omitempty" json:"maxIncomingConnections,omitempty"`
-	ServiceExecutor                  string            `yaml:"serviceExecutor,omitempty" json:"serviceExecutor,omitempty"`
-	DefaultRWConcern                 *DefaultRWConcern `yaml:"defaultRWConcern,omitempty" json:"defaultRWConcern,omitempty"` //nolint:tagliatelle // correct from API
-	DirectoryPerDB                   *bool             `yaml:"directoryPerDB,omitempty" json:"directoryPerDB,omitempty"`
-	Disabled                         bool              `yaml:"disabled" json:"disabled"`
-	Engine                           string            `yaml:"engine,omitempty" json:"engine,omitempty"`
-	EnableMajorityReadConcern        *bool             `yaml:"enableMajorityReadConcern,omitempty" json:"enableMajorityReadConcern,omitempty"`
-	FeatureCompatibilityVersion      string            `yaml:"featureCompatibilityVersion,omitempty" json:"featureCompatibilityVersion,omitempty"`
-	Hidden                           *bool             `yaml:"hidden,omitempty" json:"hidden,omitempty"`
+	ArbiterOnly                      *bool              `yaml:"arbiterOnly,omitempty" json:"arbiterOnly,omitempty"`
+	CPUAffinity                      []int              `yaml:"cpuAffinity,omitempty" json:"cpuAffinity,omitempty"`
+	AuditLogPath                     string             `yaml:"auditLogPath,omitempty" json:"auditLogPath,omitempty"`
+	AuditLogDestination              string             `yaml:"auditLogDestination,omitempty" json:"auditLogDestination,omitempty"`
+	AuditLogFormat                   string             `yaml:"auditLogFormat,omitempty" json:"auditLogFormat,omitempty"`
+	AuditLogFilter                   string             `yaml:"auditLogFilter,omitempty" json:"auditLogFilter,omitempty"`
+	BackupRestoreCheckpointTimestamp any                `yaml:"backupRestoreCheckpointTimestamp,omitempty" json:"backupRestoreCheckpointTimestamp,omitempty"`
+	BuildIndexes                     *bool              `yaml:"buildIndexes,omitempty" json:"buildIndexes,omitempty"`
+	DBPath                           string             `yaml:"dbPath,omitempty" json:"dbPath,omitempty"`
+	BindIP                           *string            `yaml:"bindIp,omitempty" json:"bindIp,omitempty"`
+	BindIPAll                        *bool              `yaml:"bindIpAll,omitempty" json:"bindIpAll,omitempty"`
+	Compression                      *map[string]any    `yaml:"compression,omitempty" json:"compression,omitempty"`
+	MaxIncomingConnections           *int               `yaml:"maxIncomingConnections,omitempty" json:"maxIncomingConnections,omitempty"`
+	ServiceExecutor                  string             `yaml:"serviceExecutor,omitempty" json:"serviceExecutor,omitempty"`
+	DefaultRWConcern                 *DefaultRWConcern  `yaml:"defaultRWConcern,omitempty" json:"defaultRWConcern,omitempty"` //nolint:tagliatelle // correct from API
+	DirectoryPerDB                   *bool              `yaml:"directoryPerDB,omitempty" json:"directoryPerDB,omitempty"`
+	Disabled                         bool               `yaml:"disabled" json:"disabled"`
+	Engine                           string             `yaml:"engine,omitempty" json:"engine,omitempty"`
+	EnableMajorityReadConcern        *bool              `yaml:"enableMajorityReadConcern,omitempty" json:"enableMajorityReadConcern,omitempty"`
+	FeatureCompatibilityVersion      string             `yaml:"featureCompatibilityVersion,omitempty" json:"featureCompatibilityVersion,omitempty"`
+	Hidden                           *bool              `yaml:"hidden,omitempty" json:"hidden,omitempty"`
 	Horizons                         *map[string]string `yaml:"horizons,omitempty" json:"horizons,omitempty"`
 	MemberTags                       *map[string]string `yaml:"memberTags,omitempty" json:"memberTags,omitempty"`
-	Hostname                         string            `yaml:"hostname" json:"hostname"`
-	InMemory                         *map[string]any   `yaml:"inMemory,omitempty" json:"inMemory,omitempty"`
-	IndexBuildRetry                  *bool             `yaml:"indexBuildRetry,omitempty" json:"indexBuildRetry,omitempty"`
-	IPV6                             *bool             `yaml:"ipv6,omitempty" json:"ipv6,omitempty"`
-	Journal                          *map[string]any   `yaml:"journal,omitempty" json:"journal,omitempty"`
-	LogAppend                        bool              `yaml:"logAppend,omitempty" json:"logAppend,omitempty"`
-	LogDestination                   string            `yaml:"logDestination,omitempty" json:"logDestination,omitempty"`
-	LogPath                          string            `yaml:"logPath" json:"logPath"`
-	LogRotate                        string            `yaml:"logRotate,omitempty" json:"logRotate,omitempty"`
-	LogVerbosity                     int               `yaml:"logVerbosity,omitempty" json:"logVerbosity,omitempty"`
-	LogQuiet                         bool              `yaml:"logQuiet,omitempty" json:"logQuiet,omitempty"`
-	SyslogFacility                   string            `yaml:"syslogFacility,omitempty" json:"syslogFacility,omitempty"`
-	LogTimeStampFormat               string            `yaml:"logTimeStampFormat,omitempty" json:"logTimeStampFormat,omitempty"`
-	Name                             string            `yaml:"name,omitempty" json:"name,omitempty"`
-	OperationProfiling               *map[string]any   `yaml:"operationProfiling,omitempty" json:"operationProfiling,omitempty"`
-	OplogMinRetentionHours           *float64          `yaml:"oplogMinRetentionHours,omitempty" json:"oplogMinRetentionHours,omitempty"`
-	OplogSizeMB                      *int              `yaml:"oplogSizeMB,omitempty" json:"oplogSizeMB,omitempty"`
-	Port                             int               `yaml:"port" json:"port"`
-	Priority                         *float64          `yaml:"priority,omitempty" json:"priority,omitempty"`
-	ProcessType                      string            `yaml:"processType" json:"processType"`
-	SmallFiles                       *bool             `yaml:"smallFiles,omitempty" json:"smallFiles,omitempty"`
-	SecondaryDelaySecs               *float64          `yaml:"secondaryDelaySecs,omitempty" json:"secondaryDelaySecs,omitempty"`
-	SlaveDelay                       *float64          `yaml:"slaveDelay,omitempty" json:"slaveDelay,omitempty"`
-	SyncPeriodSecs                   *float64          `yaml:"syncPeriodSecs,omitempty" json:"syncPeriodSecs,omitempty"`
-	Votes                            *float64          `yaml:"votes,omitempty" json:"votes,omitempty"`
-	Security                         *map[string]any   `yaml:"security,omitempty" json:"security,omitempty"`
-	SetParameter                     *map[string]any   `yaml:"setParameter,omitempty" json:"setParameter,omitempty"`
-	TLS                              *TLS              `yaml:"tls,omitempty" json:"tls,omitempty"`
-	Version                          string            `yaml:"version,omitempty" json:"version,omitempty"`
-	WiredTiger                       *map[string]any   `yaml:"wiredTiger,omitempty" json:"wiredTiger,omitempty"`
+	Hostname                         string             `yaml:"hostname" json:"hostname"`
+	InMemory                         *map[string]any    `yaml:"inMemory,omitempty" json:"inMemory,omitempty"`
+	IndexBuildRetry                  *bool              `yaml:"indexBuildRetry,omitempty" json:"indexBuildRetry,omitempty"`
+	IPV6                             *bool              `yaml:"ipv6,omitempty" json:"ipv6,omitempty"`
+	Journal                          *map[string]any    `yaml:"journal,omitempty" json:"journal,omitempty"`
+	LogAppend                        bool               `yaml:"logAppend,omitempty" json:"logAppend,omitempty"`
+	LogDestination                   string             `yaml:"logDestination,omitempty" json:"logDestination,omitempty"`
+	LogPath                          string             `yaml:"logPath" json:"logPath"`
+	LogRotate                        string             `yaml:"logRotate,omitempty" json:"logRotate,omitempty"`
+	LogVerbosity                     int                `yaml:"logVerbosity,omitempty" json:"logVerbosity,omitempty"`
+	LogQuiet                         bool               `yaml:"logQuiet,omitempty" json:"logQuiet,omitempty"`
+	SyslogFacility                   string             `yaml:"syslogFacility,omitempty" json:"syslogFacility,omitempty"`
+	LogTimeStampFormat               string             `yaml:"logTimeStampFormat,omitempty" json:"logTimeStampFormat,omitempty"`
+	Name                             string             `yaml:"name,omitempty" json:"name,omitempty"`
+	OperationProfiling               *map[string]any    `yaml:"operationProfiling,omitempty" json:"operationProfiling,omitempty"`
+	OplogMinRetentionHours           *float64           `yaml:"oplogMinRetentionHours,omitempty" json:"oplogMinRetentionHours,omitempty"`
+	OplogSizeMB                      *int               `yaml:"oplogSizeMB,omitempty" json:"oplogSizeMB,omitempty"`
+	Port                             int                `yaml:"port" json:"port"`
+	Priority                         *float64           `yaml:"priority,omitempty" json:"priority,omitempty"`
+	ProcessType                      string             `yaml:"processType" json:"processType"`
+	SmallFiles                       *bool              `yaml:"smallFiles,omitempty" json:"smallFiles,omitempty"`
+	SecondaryDelaySecs               *float64           `yaml:"secondaryDelaySecs,omitempty" json:"secondaryDelaySecs,omitempty"`
+	SlaveDelay                       *float64           `yaml:"slaveDelay,omitempty" json:"slaveDelay,omitempty"`
+	SyncPeriodSecs                   *float64           `yaml:"syncPeriodSecs,omitempty" json:"syncPeriodSecs,omitempty"`
+	Votes                            *float64           `yaml:"votes,omitempty" json:"votes,omitempty"`
+	Security                         *map[string]any    `yaml:"security,omitempty" json:"security,omitempty"`
+	SetParameter                     *map[string]any    `yaml:"setParameter,omitempty" json:"setParameter,omitempty"`
+	TLS                              *TLS               `yaml:"tls,omitempty" json:"tls,omitempty"`
+	Version                          string             `yaml:"version,omitempty" json:"version,omitempty"`
+	WiredTiger                       *map[string]any    `yaml:"wiredTiger,omitempty" json:"wiredTiger,omitempty"`
 }
 
 // TLS defines TLS parameters for Net.
@@ -188,6 +189,7 @@ func newProcessConfig(rs *opsmngr.Member, p *opsmngr.Process) *ProcessConfig {
 		Name:                             p.Name,
 		SetParameter:                     p.Args26.SetParameter,
 		BackupRestoreCheckpointTimestamp: p.BackupRestoreCheckpointTimestamp,
+		CPUAffinity:                      p.CPUAffinity,
 	}
 }
 
@@ -356,9 +358,6 @@ func (p *ProcessConfig) replicaSetArgs26(rsSetName string) opsmngr.Args26 {
 	if p.AuditLogPath != "" || p.AuditLogDestination != "" {
 		args26.AuditLog = p.auditLog()
 	}
-	if p.AuditLogPath != "" || p.AuditLogDestination != "" {
-		args26.AuditLog = p.auditLog()
-	}
 	if p.OperationProfiling != nil {
 		args26.OperationProfiling = p.OperationProfiling
 	}
@@ -393,6 +392,7 @@ func (p *ProcessConfig) net() opsmngr.Net {
 		Port:                   p.Port,
 		BindIP:                 p.BindIP,
 		BindIPAll:              p.BindIPAll,
+		IPV6:                   p.IPV6,
 		Compression:            p.Compression,
 		MaxIncomingConnections: p.MaxIncomingConnections,
 		ServiceExecutor:        p.ServiceExecutor,
@@ -498,6 +498,7 @@ func (p *ProcessConfig) process() *opsmngr.Process {
 	process := &opsmngr.Process{
 		AuthSchemaVersion:                authSchemaVersion,
 		BackupRestoreCheckpointTimestamp: p.BackupRestoreCheckpointTimestamp,
+		CPUAffinity:                      p.CPUAffinity,
 		DefaultRWConcern:                 p.defaultRW(),
 		Disabled:                         p.Disabled,
 		ManualMode:                       false,

--- a/internal/convert/process_config.go
+++ b/internal/convert/process_config.go
@@ -39,6 +39,9 @@ type ProcessConfig struct {
 	DBPath                           string            `yaml:"dbPath,omitempty" json:"dbPath,omitempty"`
 	BindIP                           *string           `yaml:"bindIp,omitempty" json:"bindIp,omitempty"`
 	BindIPAll                        *bool             `yaml:"bindIpAll,omitempty" json:"bindIpAll,omitempty"`
+	Compression                      *map[string]any   `yaml:"compression,omitempty" json:"compression,omitempty"`
+	MaxIncomingConnections           *int              `yaml:"maxIncomingConnections,omitempty" json:"maxIncomingConnections,omitempty"`
+	ServiceExecutor                  string            `yaml:"serviceExecutor,omitempty" json:"serviceExecutor,omitempty"`
 	DefaultRWConcern                 *DefaultRWConcern `yaml:"defaultRWConcern,omitempty" json:"defaultRWConcern,omitempty"` //nolint:tagliatelle // correct from API
 	DirectoryPerDB                   *bool             `yaml:"directoryPerDB,omitempty" json:"directoryPerDB,omitempty"`
 	Disabled                         bool              `yaml:"disabled" json:"disabled"`
@@ -46,6 +49,8 @@ type ProcessConfig struct {
 	EnableMajorityReadConcern        *bool             `yaml:"enableMajorityReadConcern,omitempty" json:"enableMajorityReadConcern,omitempty"`
 	FeatureCompatibilityVersion      string            `yaml:"featureCompatibilityVersion,omitempty" json:"featureCompatibilityVersion,omitempty"`
 	Hidden                           *bool             `yaml:"hidden,omitempty" json:"hidden,omitempty"`
+	Horizons                         *map[string]string `yaml:"horizons,omitempty" json:"horizons,omitempty"`
+	MemberTags                       *map[string]string `yaml:"memberTags,omitempty" json:"memberTags,omitempty"`
 	Hostname                         string            `yaml:"hostname" json:"hostname"`
 	InMemory                         *map[string]any   `yaml:"inMemory,omitempty" json:"inMemory,omitempty"`
 	IndexBuildRetry                  *bool             `yaml:"indexBuildRetry,omitempty" json:"indexBuildRetry,omitempty"`
@@ -159,6 +164,8 @@ func newProcessConfig(rs *opsmngr.Member, p *opsmngr.Process) *ProcessConfig {
 		Votes:                            &rs.Votes,
 		ArbiterOnly:                      &rs.ArbiterOnly,
 		Hidden:                           &rs.Hidden,
+		Horizons:                         rs.Horizons,
+		MemberTags:                       rs.Tags,
 		LogPath:                          p.Args26.SystemLog.Path,
 		LogDestination:                   p.Args26.SystemLog.Destination,
 		LogAppend:                        p.Args26.SystemLog.LogAppend,
@@ -170,6 +177,9 @@ func newProcessConfig(rs *opsmngr.Member, p *opsmngr.Process) *ProcessConfig {
 		Port:                             p.Args26.NET.Port,
 		BindIP:                           p.Args26.NET.BindIP,
 		BindIPAll:                        p.Args26.NET.BindIPAll,
+		Compression:                      p.Args26.NET.Compression,
+		MaxIncomingConnections:           p.Args26.NET.MaxIncomingConnections,
+		ServiceExecutor:                  p.Args26.NET.ServiceExecutor,
 		IPV6:                             p.Args26.NET.IPV6,
 		ProcessType:                      p.ProcessType,
 		Version:                          p.Version,
@@ -380,9 +390,12 @@ func newConfigRSProcess(p *ProcessConfig, rsSetName string) *opsmngr.Process {
 // net maps convert.ProcessConfig -> opsmngr.Net.
 func (p *ProcessConfig) net() opsmngr.Net {
 	net := opsmngr.Net{
-		Port:      p.Port,
-		BindIP:    p.BindIP,
-		BindIPAll: p.BindIPAll,
+		Port:                   p.Port,
+		BindIP:                 p.BindIP,
+		BindIPAll:              p.BindIPAll,
+		Compression:            p.Compression,
+		MaxIncomingConnections: p.MaxIncomingConnections,
+		ServiceExecutor:        p.ServiceExecutor,
 	}
 
 	if p.TLS != nil {
@@ -510,6 +523,8 @@ func (p *ProcessConfig) member(i int) opsmngr.Member {
 		Host:         p.Name,
 		Priority:     1,
 		Votes:        1,
+		Horizons:     p.Horizons,
+		Tags:         p.MemberTags,
 	}
 	if p.ArbiterOnly != nil {
 		m.ArbiterOnly = *p.ArbiterOnly

--- a/internal/convert/process_config_test.go
+++ b/internal/convert/process_config_test.go
@@ -450,3 +450,88 @@ func Test_newMongosProcessConfig(t *testing.T) {
 	got := newMongosProcessConfig(p)
 	assert.Equal(t, want, got)
 }
+
+func Test_netFieldsRoundtrip(t *testing.T) {
+	compression := &map[string]any{
+		"compressors": []any{"snappy", "zlib"},
+	}
+	maxConn := pointer.Get(500)
+
+	omp := &opsmngr.Process{
+		Args26: opsmngr.Args26{
+			NET: opsmngr.Net{
+				Port:                   27017,
+				Compression:            compression,
+				MaxIncomingConnections: maxConn,
+				ServiceExecutor:        "adaptive",
+			},
+			Storage:     &opsmngr.Storage{DBPath: "/data/db"},
+			SystemLog:   opsmngr.SystemLog{Destination: "file", Path: "/data/log/mongodb.log"},
+			Replication: &opsmngr.Replication{ReplSetName: "myRS"},
+		},
+		FeatureCompatibilityVersion: "4.4",
+		Hostname:                    "host0",
+		Name:                        "myRS_1",
+		ProcessType:                 "mongod",
+		Version:                     "4.4.1",
+	}
+	omm := &opsmngr.Member{
+		BuildIndexes: true,
+		Host:         "myRS_1",
+		Priority:     1,
+		Votes:        1,
+	}
+
+	// Describe direction
+	pc := newReplicaSetProcessConfig(omm, omp)
+	assert.Equal(t, compression, pc.Compression)
+	assert.Equal(t, maxConn, pc.MaxIncomingConnections)
+	assert.Equal(t, "adaptive", pc.ServiceExecutor)
+
+	// Update direction
+	n := pc.net()
+	assert.Equal(t, compression, n.Compression)
+	assert.Equal(t, maxConn, n.MaxIncomingConnections)
+	assert.Equal(t, "adaptive", n.ServiceExecutor)
+}
+
+func Test_memberFieldsRoundtrip(t *testing.T) {
+	horizons := &map[string]string{
+		"external": "external-host:27017",
+	}
+	tags := &map[string]string{
+		"region": "us-east-1",
+		"usage":  "analytics",
+	}
+	omm := &opsmngr.Member{
+		BuildIndexes: true,
+		Host:         "myRS_1",
+		Priority:     1,
+		Votes:        1,
+		Horizons:     horizons,
+		Tags:         tags,
+	}
+	omp := &opsmngr.Process{
+		Args26: opsmngr.Args26{
+			NET:         opsmngr.Net{Port: 27017},
+			Storage:     &opsmngr.Storage{DBPath: "/data"},
+			SystemLog:   opsmngr.SystemLog{Destination: "file", Path: "/log"},
+			Replication: &opsmngr.Replication{ReplSetName: "myRS"},
+		},
+		FeatureCompatibilityVersion: "4.4",
+		Hostname:                    "host0",
+		Name:                        "myRS_1",
+		ProcessType:                 "mongod",
+		Version:                     "4.4.1",
+	}
+
+	// Describe direction
+	pc := newReplicaSetProcessConfig(omm, omp)
+	assert.Equal(t, horizons, pc.Horizons)
+	assert.Equal(t, tags, pc.MemberTags)
+
+	// Update direction
+	m := pc.member(0)
+	assert.Equal(t, horizons, m.Horizons)
+	assert.Equal(t, tags, m.Tags)
+}

--- a/internal/convert/process_config_test.go
+++ b/internal/convert/process_config_test.go
@@ -535,3 +535,35 @@ func Test_memberFieldsRoundtrip(t *testing.T) {
 	assert.Equal(t, horizons, m.Horizons)
 	assert.Equal(t, tags, m.Tags)
 }
+
+func Test_processFieldsRoundtrip(t *testing.T) {
+	cpuAffinity := []int{0, 1, 2, 3}
+	omp := &opsmngr.Process{
+		Args26: opsmngr.Args26{
+			NET:         opsmngr.Net{Port: 27017},
+			Storage:     &opsmngr.Storage{DBPath: "/data"},
+			SystemLog:   opsmngr.SystemLog{Destination: "file", Path: "/log"},
+			Replication: &opsmngr.Replication{ReplSetName: "myRS"},
+		},
+		CPUAffinity:                 cpuAffinity,
+		FeatureCompatibilityVersion: "4.4",
+		Hostname:                    "host0",
+		Name:                        "myRS_1",
+		ProcessType:                 "mongod",
+		Version:                     "4.4.1",
+	}
+	omm := &opsmngr.Member{
+		BuildIndexes: true,
+		Host:         "myRS_1",
+		Priority:     1,
+		Votes:        1,
+	}
+
+	// Describe direction
+	pc := newReplicaSetProcessConfig(omm, omp)
+	assert.Equal(t, cpuAffinity, pc.CPUAffinity)
+
+	// Update direction
+	proc := pc.process()
+	assert.Equal(t, cpuAffinity, proc.CPUAffinity)
+}

--- a/internal/convert/rs_config.go
+++ b/internal/convert/rs_config.go
@@ -24,11 +24,13 @@ import (
 
 // RSConfig shared properties of replica sets, config servers, and sharded clusters.
 type RSConfig struct {
-	Name                        string            `yaml:"name,omitempty" json:"name,omitempty"`
-	FeatureCompatibilityVersion string            `yaml:"featureCompatibilityVersion,omitempty" json:"featureCompatibilityVersion,omitempty"`
-	Processes                   []*ProcessConfig  `yaml:"processes,omitempty" json:"processes,omitempty"`
-	Tags                        []*map[string]any `yaml:"tags,omitempty" json:"tags,omitempty"`
-	Version                     string            `yaml:"version,omitempty" json:"version,omitempty"`
+	Name                               string            `yaml:"name,omitempty" json:"name,omitempty"`
+	FeatureCompatibilityVersion        string            `yaml:"featureCompatibilityVersion,omitempty" json:"featureCompatibilityVersion,omitempty"`
+	Processes                          []*ProcessConfig  `yaml:"processes,omitempty" json:"processes,omitempty"`
+	Tags                               []*map[string]any `yaml:"tags,omitempty" json:"tags,omitempty"`
+	Version                            string            `yaml:"version,omitempty" json:"version,omitempty"`
+	Settings                           *map[string]any   `yaml:"settings,omitempty" json:"settings,omitempty"`
+	WriteConcernMajorityJournalDefault string            `yaml:"writeConcernMajorityJournalDefault,omitempty" json:"writeConcernMajorityJournalDefault,omitempty"`
 }
 
 type patcher func(*ProcessConfig, string) *opsmngr.Process
@@ -110,9 +112,11 @@ func newReplicaSet(c *RSConfig) (*opsmngr.ReplicaSet, error) {
 	}
 
 	rs := &opsmngr.ReplicaSet{
-		ID:              c.Name,
-		Members:         make([]opsmngr.Member, len(c.Processes)),
-		ProtocolVersion: pv,
+		ID:                                 c.Name,
+		Members:                            make([]opsmngr.Member, len(c.Processes)),
+		ProtocolVersion:                    pv,
+		Settings:                           c.Settings,
+		WriteConcernMajorityJournalDefault: c.WriteConcernMajorityJournalDefault,
 	}
 
 	return rs, nil
@@ -128,8 +132,10 @@ func newRSConfig(in *opsmngr.AutomationConfig, id string) *RSConfig {
 	}
 	rs := in.ReplicaSets[rsi]
 	out := &RSConfig{
-		Name:      rs.ID,
-		Processes: make([]*ProcessConfig, len(rs.Members)),
+		Name:                               rs.ID,
+		Processes:                          make([]*ProcessConfig, len(rs.Members)),
+		Settings:                           rs.Settings,
+		WriteConcernMajorityJournalDefault: rs.WriteConcernMajorityJournalDefault,
 	}
 
 	for i, m := range rs.Members {

--- a/internal/convert/rs_config_test.go
+++ b/internal/convert/rs_config_test.go
@@ -16,7 +16,74 @@
 
 package convert
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/ops-manager/opsmngr"
+)
+
+func TestRSConfig_SettingsRoundtrip(t *testing.T) {
+	t.Parallel()
+	settings := &map[string]any{
+		"chainingAllowed":            true,
+		"heartbeatTimeoutSecs":       float64(10),
+		"electionTimeoutMillis":      float64(10000),
+		"catchUpTimeoutMillis":       float64(-1),
+		"catchUpTakeoverDelayMillis": float64(30000),
+		"getLastErrorDefaults":       map[string]any{"w": float64(1), "wtimeout": float64(0)},
+	}
+	in := &opsmngr.AutomationConfig{
+		Processes: []*opsmngr.Process{
+			{
+				Name:                        "myRS_1",
+				ProcessType:                 "mongod",
+				Version:                     "4.2.2",
+				FeatureCompatibilityVersion: "4.2",
+				Hostname:                    "host0",
+				Args26: opsmngr.Args26{
+					NET:     opsmngr.Net{Port: 27000},
+					Storage: &opsmngr.Storage{DBPath: "/data"},
+					SystemLog: opsmngr.SystemLog{
+						Destination: "file",
+						Path:        "/data/mongodb.log",
+					},
+					Replication: &opsmngr.Replication{ReplSetName: "myRS"},
+				},
+			},
+		},
+		ReplicaSets: []*opsmngr.ReplicaSet{
+			{
+				ID:              "myRS",
+				ProtocolVersion: "1",
+				Members: []opsmngr.Member{
+					{
+						ID:           0,
+						ArbiterOnly:  false,
+						BuildIndexes: true,
+						Host:         "myRS_1",
+						Priority:     1,
+						Votes:        1,
+					},
+				},
+				Settings:                           settings,
+				WriteConcernMajorityJournalDefault: "true",
+			},
+		},
+	}
+
+	// Describe direction: automation config → RSConfig
+	rsConfig := newRSConfig(in, "myRS")
+	assert.NotNil(t, rsConfig)
+	assert.Equal(t, settings, rsConfig.Settings)
+	assert.Equal(t, "true", rsConfig.WriteConcernMajorityJournalDefault)
+
+	// Update direction: RSConfig → opsmngr.ReplicaSet
+	rs, err := newReplicaSet(rsConfig)
+	assert.NoError(t, err)
+	assert.Equal(t, settings, rs.Settings)
+	assert.Equal(t, "true", rs.WriteConcernMajorityJournalDefault)
+}
 
 func TestRSConfig_protocolVer(t *testing.T) {
 	testCases := map[string]struct {

--- a/internal/convert/rs_config_test.go
+++ b/internal/convert/rs_config_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -80,7 +81,7 @@ func TestRSConfig_SettingsRoundtrip(t *testing.T) {
 
 	// Update direction: RSConfig → opsmngr.ReplicaSet
 	rs, err := newReplicaSet(rsConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, settings, rs.Settings)
 	assert.Equal(t, "true", rs.WriteConcernMajorityJournalDefault)
 }

--- a/internal/test/fixture/automation_configs.go
+++ b/internal/test/fixture/automation_configs.go
@@ -198,6 +198,9 @@ func AutomationConfigWithOneReplicaSet(name string, disabled bool) *opsmngr.Auto
 				Args26: opsmngr.Args26{
 					NET: opsmngr.Net{
 						Port: defaultMongoDPort,
+						Compression: &map[string]any{
+							"compressors": []any{"snappy"},
+						},
 						TLS: &opsmngr.TLS{
 							CAFile:                     "CAFile",
 							CertificateKeyFile:         "CertificateKeyFile",
@@ -260,8 +263,15 @@ func AutomationConfigWithOneReplicaSet(name string, disabled bool) *opsmngr.Auto
 						SlaveDelay:         pointer.Get[float64](1),
 						SecondaryDelaySecs: pointer.Get[float64](1),
 						Votes:              1,
+						Tags: &map[string]string{
+							"region": "us-east-1",
+						},
 					},
 				},
+				Settings: &map[string]any{
+					"chainingAllowed": true,
+				},
+				WriteConcernMajorityJournalDefault: "true",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- Fix lossy describe→update roundtrip in `internal/convert/` that silently drops replica set settings, net compression, member tags/horizons, and CPU affinity
- Add explicit field mappings for `ReplicaSet.Settings`, `WriteConcernMajorityJournalDefault`, `Net.Compression`, `Net.MaxIncomingConnections`, `Net.ServiceExecutor`, `Member.Horizons`, `Member.Tags`, and `Process.CPUAffinity`
- Extend `keepSettings()` as defense-in-depth for hand-written config files

## Out of scope

- `numactl.numCores` — requires upstream SDK change (`go.mongodb.org/ops-manager` has no `NumaCtl` field on `Process`)

## Test plan

- [x] New unit tests for each field roundtrip (RS settings, net fields, member fields, CPU affinity, keepSettings)
- [x] Updated fixtures in `AutomationConfigWithOneReplicaSet` to exercise new fields
- [x] All existing convert package tests updated and passing
- [x] `golangci-lint` clean on `./internal/convert/...`